### PR TITLE
Some fixes for CentOS 7 (systemd)

### DIFF
--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -327,7 +327,7 @@
 					fi
 					yum install -y postgresql94-server postgresql04-contrib
 
-                    ps -q 1 | grep -c "systemd"
+                    ps -q 1 | grep -q -c "systemd"
                     if [ "$?" -eq 0 ]; then
                         if [ -f /usr/pgsql-9.4/bin/postgresql94-setup ]; then
                             /usr/pgsql-9.4/bin/postgresql94-setup initdb
@@ -344,7 +344,7 @@
 					mv pg_hba.conf pg_hba.conf_old
 					mv pg_hba.conf.1 pg_hba.conf
                     
-                    ps -q 1 | grep -c "systemd"
+                    ps -q 1 | grep -q -c "systemd"
                     if [ "$?" -eq 0 ]; then
                         systemctl restart postgresql-9.4.service
                     else
@@ -435,7 +435,7 @@
 			echo "0 * * * * $dir/server/php/R/shell/periodic_email_notification.sh" >> /var/spool/cron/root
 
 			# Start services
-            ps -q 1 | grep -c "systemd"
+            ps -q 1 | grep -q -c "systemd"
             if [ "$?" -eq 0 ]; then
                 echo "Starting services with systemd"
                 systemctl start nginx

--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -399,7 +399,7 @@
 			chmod -R go+w $dir/media
 			chmod -R go+w $dir/client/img
 			chmod -R go+w $dir/tmp/cache
-			chmod -R go+w $dir/server/php/R/shell/*.sh
+			chmod -R 0755 $dir/server/php/R/shell/*.sh
 
 			psql -U postgres -c "\q"	
 			sleep 1

--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -401,11 +401,7 @@
 			chmod -R go+w $dir/tmp/cache
 			chmod -R go+w $dir/server/php/R/shell/cron/*.sh
 
-			psql -U postgres -c "\q"
-			if [ "$?" = 0 ];
-			then
-				break
-			fi	
+			psql -U postgres -c "\q"	
 			sleep 1
 
 			echo "Creating PostgreSQL user and database..."

--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -430,13 +430,13 @@
 			  $dir/server/php/R/config.inc.php
 			
 			echo "Setting up cron for every 5 minutes to update ElasticSearch indexing..."
-			echo '*/5 * * * * $dir/server/php/R/shell/cron.sh' >> /var/spool/cron/root
+			echo "*/5 * * * * $dir/server/php/R/shell/cron.sh" >> /var/spool/cron/root
 			
 			echo "Setting up cron for every 5 minutes to send email notification to user, if the user chosen notification type as instant..."
-			echo '*/5 * * * * $dir/server/php/R/shell/instant_email_notification.sh' >> /var/spool/cron/root
+			echo "*/5 * * * * $dir/server/php/R/shell/instant_email_notification.sh" >> /var/spool/cron/root
 			
 			echo "Setting up cron for every 1 hour to send email notification to user, if the user chosen notification type as periodic..."
-			echo '0 * * * * $dir/server/php/R/shell/periodic_email_notification.sh' >> /var/spool/cron/root
+			echo "0 * * * * $dir/server/php/R/shell/periodic_email_notification.sh" >> /var/spool/cron/root
 
 			# Start services
             ps -q 1 | grep -c "systemd"

--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -399,7 +399,7 @@
 			chmod -R go+w $dir/media
 			chmod -R go+w $dir/client/img
 			chmod -R go+w $dir/tmp/cache
-			chmod -R go+w $dir/server/php/R/shell/cron/*.sh
+			chmod -R go+w $dir/server/php/R/shell/*.sh
 
 			psql -U postgres -c "\q"	
 			sleep 1

--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -41,10 +41,10 @@
 			sleep 1
 			
 			echo "Setting up cron for every 5 minutes to send email notification to user, if the user chosen notification type as instant..."
-			echo '*/5 * * * * $dir/server/php/R/shell/instant_email_notification.sh' >> /var/spool/cron/root
+			echo "*/5 * * * * $dir/server/php/R/shell/instant_email_notification.sh" >> /var/spool/cron/root
 			
 			echo "Setting up cron for every 1 hour to send email notification to user, if the user chosen notification type as periodic..."
-			echo '0 * * * * $dir/server/php/R/shell/periodic_email_notification.sh' >> /var/spool/cron/root
+			echo "0 * * * * $dir/server/php/R/shell/periodic_email_notification.sh" >> /var/spool/cron/root
 			
 			echo "Updating SQL..."
 			psql -d ${POSTGRES_DBNAME} -f $dir/sql/${RESTYABOARD_VERSION}.sql -U ${POSTGRES_DBUSER}
@@ -229,13 +229,13 @@
 			$dir/server/php/R/config.inc.php
 			
 			echo "Setting up cron for every 5 minutes to update ElasticSearch indexing..."
-			echo '*/5 * * * * $dir/server/php/R/shell/cron.sh' >> /var/spool/cron/root
+			echo "*/5 * * * * $dir/server/php/R/shell/cron.sh" >> /var/spool/cron/root
 			
 			echo "Setting up cron for every 5 minutes to send email notification to user, if the user chosen notification type as instant..."
-			echo '*/5 * * * * $dir/server/php/R/shell/instant_email_notification.sh' >> /var/spool/cron/root
+			echo "*/5 * * * * $dir/server/php/R/shell/instant_email_notification.sh" >> /var/spool/cron/root
 			
 			echo "Setting up cron for every 1 hour to send email notification to user, if the user chosen notification type as periodic..."
-			echo '0 * * * * $dir/server/php/R/shell/periodic_email_notification.sh' >> /var/spool/cron/root
+			echo "0 * * * * $dir/server/php/R/shell/periodic_email_notification.sh" >> /var/spool/cron/root
 
 			echo "Starting services..."
 			service cron restart

--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -320,10 +320,10 @@
 					[Yy])
 					echo "Installing PostgreSQL..."
 					if [ $(getconf LONG_BIT) = "32" ]; then
-						yum install http://yum.postgresql.org/9.4/redhat/rhel-6.6-i386/pgdg-centos94-9.4-1.noarch.rpm
+						yum install -y http://yum.postgresql.org/9.4/redhat/rhel-6.6-i386/pgdg-centos94-9.4-1.noarch.rpm
 					fi
 					if [ $(getconf LONG_BIT) = "64" ]; then
-						yum install http://yum.postgresql.org/9.4/redhat/rhel-6.6-x86_64/pgdg-centos94-9.4-1.noarch.rpm
+						yum install -y http://yum.postgresql.org/9.4/redhat/rhel-6.6-x86_64/pgdg-centos94-9.4-1.noarch.rpm
 					fi
 					yum install -y postgresql94-server postgresql04-contrib
 


### PR DESCRIPTION
modified script so it will still run as expected on older systems but will use systemd calls where the installer failed previously.
CentOS 7 does not include "unzip", added check and yum install

Installation script still has issues since it does not create a working system. Will try to fix remaining issues in the next few days.

This version will run to the end