### PR TITLE
Changed length requirements on username and password

### DIFF
--- a/client/js/templates/admin_user_add.jst.ejs
+++ b/client/js/templates/admin_user_add.jst.ejs
@@ -9,7 +9,7 @@
 	  </div>
 	  <div class="form-group required">
 		<label class="sr-only control-label" for="inputUsername">Username</label>
-		<input type="name" name="username" id="inputUsername" class="form-control" placeholder="Username" required pattern=".{6,15}" title="Username. Minimum 6 characters">
+		<input type="name" name="username" id="inputUsername" class="form-control" placeholder="Username" required pattern=".{3,15}" title="Username. Minimum 3 characters">
 	  </div>
 	  <div class="form-group required">
 		<label class="sr-only control-label" for="inputPassword">Password</label>

--- a/client/js/templates/admin_user_add.jst.ejs
+++ b/client/js/templates/admin_user_add.jst.ejs
@@ -13,7 +13,7 @@
 	  </div>
 	  <div class="form-group required">
 		<label class="sr-only control-label" for="inputPassword">Password</label>
-		<input type="password" required name="password" id="inputPassword"class="form-control" placeholder="Password" pattern="[A-Za-z0-9\S]{6,15}" title="Password. Minimum 6 characters and white space not allowed">
+		<input type="password" required name="password" id="inputPassword"class="form-control" placeholder="Password" pattern="[A-Za-z0-9\S]{6,50}" title="Password. Minimum 6 characters and white space not allowed">
 	  </div>
 	  <div class="form-group">
 		<label class="sr-only control-label" for="submitAddUser">Join Now</label>

--- a/client/js/templates/users_register.jst.ejs
+++ b/client/js/templates/users_register.jst.ejs
@@ -13,7 +13,7 @@
 	  </div>
 	  <div class="form-group required">
 		<label class="sr-only control-label" for="inputPassword">Password</label>
-		<input type="password" required name="password" id="inputPassword"class="form-control" placeholder="Password" pattern="[A-Za-z0-9\S]{6,15}" title="Password. Minimum 6 characters and white space not allowed">
+		<input type="password" required name="password" id="inputPassword"class="form-control" placeholder="Password" pattern="[A-Za-z0-9\S]{6,50}" title="Password. Minimum 6 characters and white space not allowed">
 	  </div>
 	  <div class="form-group">
 		<label class="sr-only ontrol-label" for="submitRegister">Join Now</label>

--- a/client/js/templates/users_register.jst.ejs
+++ b/client/js/templates/users_register.jst.ejs
@@ -9,7 +9,7 @@
 	  </div>
 	  <div class="form-group required">
 		<label class="sr-only control-label" for="inputUsername">Username</label>
-		<input type="name" name="username" id="inputUsername" class="form-control" placeholder="Username" required pattern=".{6,15}" title="Username. Minimum 6 characters">
+		<input type="name" name="username" id="inputUsername" class="form-control" placeholder="Username" required pattern=".{3,15}" title="Username. Minimum 3 characters">
 	  </div>
 	  <div class="form-group required">
 		<label class="sr-only control-label" for="inputPassword">Password</label>
@@ -23,13 +23,13 @@
 	  		<%
 			  if(!_.isEmpty(role_links.where({slug: "users_login"}))){
 			%>
-				
+
 			<%
 			  }
 			%>
 		  <% if(!_.isEmpty(role_links.where({slug: "users_forgotpassword"}))){ %>
 		  	<li><a href="#/users/forgotpassword" title="Forgot your password?" class="text-primary">Forgot your password?</a></li>
-			
+
 			<% }%>
 		</ul>
 	</form>


### PR DESCRIPTION
Changed the minimum length requirement on usernames to 3 characters, to allow for short simple first names to be used as usernames. 
Changed the maximum allowed length for passwords from 15 to 50, to allow for longer passwords. 