### PR TITLE
fixed #907: In user roles, the XMPP chat login and chat history are displayed twice.

### DIFF
--- a/sql/upgrade-0.3-0.4.sql
+++ b/sql/upgrade-0.3-0.4.sql
@@ -354,3 +354,11 @@ Restyaboard<br>
 </footer>
 </body>
 </html>', 'SITE_URL, SITE_NAME, CONTACT_EMAIL, NAME', 'LDAP Welcome');
+
+DELETE FROM acl_links_roles WHERE id IN (SELECT id FROM  acl_links WHERE name='XMPP chat login' ORDER BY id DESC LIMIT 1);
+
+DELETE FROM acl_links WHERE id  = (SELECT id FROM acl_links WHERE name='XMPP chat login' ORDER BY id DESC LIMIT 1);
+
+DELETE FROM acl_links_roles WHERE id IN (SELECT id FROM  acl_links WHERE name='Chat History' ORDER BY id DESC LIMIT 1);
+
+DELETE FROM acl_links WHERE id  = (SELECT id FROM acl_links WHERE name='Chat History' ORDER BY id DESC LIMIT 1);


### PR DESCRIPTION
fixed #907: In user roles, the XMPP chat login and chat history are displayed twi