### PR TITLE
fixes #993: Divider on card modal is not completely resizeable fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -1036,8 +1036,6 @@ App.ModalCardView = Backbone.View.extend({
             }
             $this.resizable({
                 handles: 'e',
-                minWidth: 110,
-                maxWidth: 490,
                 resize: function(event, ui) {
                     var x = ui.element.outerWidth();
                     var ele = ui.element;


### PR DESCRIPTION
fixes #993: Divider on card modal is not completely resizeable fixed