### PR TITLE
Forbidden change password via users update API

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -4511,6 +4511,9 @@ function r_put($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_put)
             $comment = '';
             $response['success'] = 'Language changed successfully.';
         }
+        if (isset($r_put['password'])) {
+            unset($r_put['password']);
+        }
         $foreign_ids['user_id'] = $authUser['id'];
         $response = update_query($table_name, $id, $r_resource_cmd, $r_put, $comment, $activity_type, $foreign_ids);
         echo json_encode($response);


### PR DESCRIPTION
If we send password in users update API, Restya change the password, but don't crypt it, so it's impossible to connect.
As we have changepassword API route, I think it's better to forcing using it and disable the password modification from the user route update.