### PR TITLE
fixes #1422 : While adding card in Boards page via instant add card, cannot able to add due date immediately issue fixed

### DIFF
--- a/client/js/templates/card_duedate_from.jst.ejs
+++ b/client/js/templates/card_duedate_from.jst.ejs
@@ -2,7 +2,7 @@
 	var currentdate = new Date();
 	var date = currentdate.getFullYear() + '-' + (((currentdate.getMonth() + 1) < 10 ) ? '0'+ (currentdate.getMonth() + 1 ) : (currentdate.getMonth() + 1)) + '-' + ((currentdate.getDate() < 10)? '0' + currentdate.getDate() : currentdate.getDate());
 	var time = currentdate.getHours() + ':' + (currentdate.getMinutes() < 10 ? '0' : '') + currentdate.getMinutes();
-	if (!_.isUndefined(this.model.attributes.due_date) && this.model.attributes.due_date !== null && this.model.attributes.due_date !== 'NULL') {
+	if (!_.isEmpty(this.model.attributes.due_date) && this.model.attributes.due_date !== 'NULL' && this.model.attributes.due_date !== 'null') {
 		var date_time = this.model.attributes.due_date.replace('T',' ');
 		date_time = date_time.split(' ');
 		date = date_time[0];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now when adding card in Boards page via instant add card, we can create due date for Card by clicking Due Date

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![due_date_form_fix](https://user-images.githubusercontent.com/17172525/34092155-11edd854-e3e8-11e7-9798-01f23a0d9467.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
