### PR TITLE
Fixes #1441: In users page, after searched Role not displaying issue fixed

### DIFF
--- a/client/js/views/user_index_container_view.js
+++ b/client/js/views/user_index_container_view.js
@@ -104,6 +104,7 @@ App.UserIndexContainerView = Backbone.View.extend({
                 $('.js-user-list').html('');
                 if (users.length !== 0) {
                     users.each(function(user) {
+                        user.roles = response.roles;
                         $('.js-user-list').append(new App.UserIndex({
                             model: user
                         }).el);
@@ -151,6 +152,7 @@ App.UserIndexContainerView = Backbone.View.extend({
                 $('.js-user-list').html('');
                 if (users.length !== 0) {
                     users.each(function(user) {
+                        user.roles = response.roles;
                         $('.js-user-list').append(new App.UserIndex({
                             model: user
                         }).el);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now in users page when search for particular user the role will be displayed

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![user_pagewithrole](https://user-images.githubusercontent.com/17172610/34429991-a850aef2-ec85-11e7-9074-1988ce5d4147.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
