### PR TITLE
Fixes #1445: Organizations - recent activity & created - not displaying issue fixed

### DIFF
--- a/client/js/templates/organizations_list_view.jst.ejs
+++ b/client/js/templates/organizations_list_view.jst.ejs
@@ -93,8 +93,8 @@ var organization_user_role_id = 0;
 					<dl class="clearfix text-center list-group-item-heading">
 						<dt>
 							<div class="btn-group navbar-btn list-activity"> <a href="#" class="btn btn-default js-no-action htruncate">
-							<% var modified = parse_date(organization.attributes.modified, authuser); %>
-							<abbr class="" title="<%- modified.datetime %>"><%- modified.timeago %></abbr>
+							<% parse_date(organization.attributes.modified, authuser, 'js-timeago-'+organization.attributes.username); %>
+							<span class="js-timeago-<%- organization.attributes.username %>"></span>
 							</a> </div>
 						</dt>
 						<dd><h6 class="text-center h4 navbar-btn"><%- i18next.t('Recent activity') %></h6></dd>
@@ -103,8 +103,8 @@ var organization_user_role_id = 0;
 					<dl class="clearfix text-center list-group-item-heading">
 						<dt>
 							<div class="btn-group navbar-btn list-activity"> <a href="#" class="btn btn-default js-no-action htruncate">
-							<% var created = parse_date(organization.attributes.created, authuser); %>
-							<abbr class="" title="<%- created.datetime %>"><%- created.timeago %></abbr>
+							<% parse_date(organization.attributes.created, authuser, 'js-timeago-'+organization.attributes.id); %>
+							<span class="js-timeago-<%- organization.attributes.id %>"></span>
 
 							</a> </div>
 						</dt>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now in orgaizations page orgaizations have Recent activity time,created time

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![organization_timeago](https://user-images.githubusercontent.com/17172610/34430305-ab727f9e-ec89-11e7-8462-56c4e1afb52d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
