### PR TITLE
Fixes #1452: Description changes are not highlighted in admin activites page issue fixed

### DIFF
--- a/client/js/templates/admin_activity_index.jst.ejs
+++ b/client/js/templates/admin_activity_index.jst.ejs
@@ -47,7 +47,7 @@
 					<%= makeLink(converter.makeHtml(activity.attributes.comment), activity.attributes.board_id) %> 
 				<% } %>
 			</span>
-			<% if(activity.attributes.difference != null && _.contains(['update_card_comment', 'edit_list', 'edit_organization', 'edit_board', 'update_card_checklist', 'update_profile', 'edit_card', 'delete_card_comment', 'edit_list_color', 'delete_list_color'], activity.attributes.type)) { %>
+			<% if(activity.attributes.difference != null && _.contains(['update_card_comment', 'edit_list', 'edit_organization', 'edit_board', 'update_card_checklist', 'update_profile', 'edit_card', 'delete_card_comment', 'edit_list_color', 'delete_list_color', 'edit_card_desc'], activity.attributes.type)) { %>
                 <div class="thumbnail media-body no-mar">
 					<% _.each(activity.attributes.difference, function(difference) { %>
 						<%= converter.makeHtml(difference) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now when the description of card modified it will be highlighted in admin activities page.

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![description_highlight](https://user-images.githubusercontent.com/17172525/34518074-a7ee0b0e-f0a3-11e7-8ab6-c90d03722d16.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
