### PR TITLE
Fixes #1458 : In user profile cards page,modal card not opening when we click on any card issue fixed

### DIFF
--- a/client/js/templates/user_cards.jst.ejs
+++ b/client/js/templates/user_cards.jst.ejs
@@ -19,7 +19,7 @@
 			<td>
 				<div class="panel cur" id="js-card-1449">
 					<div class="panel-body"> 
-						<ul class="list-inline navbar-btn clearfix">
+						<ul class="list-inline navbar-btn clearfix js-open-model-car-view" data-id="<%- user_card.id%>">
 							<li class="col-md-1 col-xs-2"><span class="card-id">#<%- user_card.id%></span></li>
 							<li class="col-md-4 col-xs-3 js-open-model-car-view" data-id="<%- user_card.id%>"><%- user_card.attributes.name %></li> 
 							<li class="col-md-4 col-xs-3"><%- user_card.attributes.list_name %></li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now  In user profile cards page,modal card will open when we click on any card

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![user_card_crop](https://user-images.githubusercontent.com/17172525/34552637-aaf706c0-f148-11e7-954e-458584ca2129.png)
![modal_card_user](https://user-images.githubusercontent.com/17172525/34552679-e7fc6d30-f148-11e7-835a-203cb18be954.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
