### PR TITLE
Fixes #1478 : In Users page when selecting all users using select:All  option admin also got selected issue fixed

### DIFF
--- a/client/js/templates/user.jst.ejs
+++ b/client/js/templates/user.jst.ejs
@@ -1,7 +1,7 @@
 <td>
     <div class="form-group text-center">
 	    <div class="checkbox">
-            <input <% if(user.attributes.role_id == 1){%>disabled<%}%> id="<%- user.attributes.id%>"  name="user_id[<%- user.attributes.id %>]" value="<%- user.attributes.id%>" class="js-checkbox-list <%if(parseInt(user.attributes.is_active) === 1){%>js-checkbox-active<%}else{%>js-checkbox-inactive<%}%><% if(!user.attributes.is_email_confirmed){ %> js-checkbox-unconfirmed<%}%>" type="checkbox">
+            <input <% if(user.attributes.role_id == 1){%>disabled<%}%> id="<%- user.attributes.id%>"  name="user_id[<%- user.attributes.id %>]" value="<%- user.attributes.id%>" class="<% if(user.attributes.role_id != 1){%> js-checkbox-list <%}%><%if(parseInt(user.attributes.is_active) === 1){%>js-checkbox-active<%}else{%>js-checkbox-inactive<%}%><% if(!user.attributes.is_email_confirmed){ %> js-checkbox-unconfirmed<%}%>" type="checkbox">
             <label class="js-update-user" data-user_id="<%- user.attributes.id %>" for="<%- user.attributes.id%>"></label>
         </div>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now when selecting all users in users page admin is not selected

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![admin_users](https://user-images.githubusercontent.com/17172525/34983002-1d9cbe8a-fad2-11e7-8c37-4329c10dae7f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
