### PR TITLE
Fixes #1462 : custom_field labels are not truncated in elasticsearch issue fixed

### DIFF
--- a/client/css/custom.less
+++ b/client/css/custom.less
@@ -2498,3 +2498,14 @@ header{
 	display: inline-block;
     padding: 5px 0 0 5px;
 }
+.js-custom_field-labels{
+	label{	
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			display: inline-block;
+			width: 115px;
+			line-height: 14px;
+			vertical-align: top;
+		}
+}


### PR DESCRIPTION
## Description
 Now custom_field labels are truncated in elastic search

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
