### PR TITLE
Fixes #1501 : Tooltip constantly display in footer logo issue fixed

### DIFF
--- a/client/js/views/application_view.js
+++ b/client/js/views/application_view.js
@@ -25,6 +25,7 @@ App.ApplicationView = Backbone.View.extend({
     initialize: function(options) {
         $('#content').html('');
         $('#footer').removeClass('action-open');
+        $('.tooltip').remove();
         var page = this;
         page.options = options;
         page.page_view_type = options.type;


### PR DESCRIPTION
## Description
 Now ,while directing to different pages, the tooltip in the footer won't display constantly

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![tooltip_removed](https://user-images.githubusercontent.com/17172525/35206958-22e4c4c6-ff66-11e7-8220-ff6f3c2a6f47.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
