### PR TITLE
Fixes #1503 : Design change in Delete organization button in organiztion/id page issue fixed

### DIFF
--- a/client/js/templates/organization_header.jst.ejs
+++ b/client/js/templates/organization_header.jst.ejs
@@ -21,10 +21,8 @@
 					</li>
 					<li class="col-xs-12 divider"></li>
 					<li>
-						<a class="js-delete-organization show clearfix small well-xs" href="#">
-							<span class="show text-primary col-xs-12 navbar-btn h5"><%- i18next.t('Remove from organization') %></span>
-							<span class="col-xs-12 navbar-btn"><%- i18next.t("Deleting an organization is permanent. Are you sure you want to delete this organization? There is no undo. Boards with this organization won't be deleted. Your boards in this organization will appear in your personal boards list.") %></span>
-						</a>
+						<span class="col-xs-12 navbar-btn"><%- i18next.t("Deleting an organization is permanent. Are you sure you want to delete this organization? There is no undo. Boards with this organization won't be deleted. Your boards in this organization will appear in your personal boards list.") %></span>
+						<div class="btn-block navbar-btn"><a title="<%- i18next.t('Delete Organization') %>" class="js-delete-organization col-xs-12"><span class="btn btn-primary col-xs-12"><%- i18next.t('Delete Forever') %></span></a></div>
 					</li>					
 			</ul>
 		</li>


### PR DESCRIPTION
## Description
 Now when users click delete button in organization/id page the Delete button will be shown along with 
 text

## Related Issue
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![delete_org](https://user-images.githubusercontent.com/17172525/35208268-76b2d546-ff6d-11e7-8a4c-a88d16a50404.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
