### PR TITLE
Fixes #1510 : Time based filter moved up before label based filter for Filter Cards in Board Header

### DIFF
--- a/client/js/templates/board_filter.jst.ejs
+++ b/client/js/templates/board_filter.jst.ejs
@@ -11,6 +11,13 @@
 	<form><div class="form-group"><input class="js-filter-cards form-control" id="inputSearchBoardLabels" name="name"><span>Type to filter labels, members.</span></div></form>
 </div>
 <% } %>
+	<ul class="nav nav-pills nav-stacked js-board-dues">
+		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Due in the next day') %> <span class="js-due hide">day</span></div></li>
+		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Due in the next week') %> <span class="js-due hide">week</span></div></li>
+		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Due in the next month') %> <span class="js-due hide">month</span></div></li>
+		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Overdue') %> <span class="js-due hide">overdue</span></div></li>
+	</ul>
+	<hr>
 	<% if (board.labels.length > 0) { %>
 	<ul class="nav nav-pills nav-stacked js-board-labels">
 	<%
@@ -56,13 +63,6 @@
 	</ul>
 	<hr>
 	<% } %>
-	<ul class="nav nav-pills nav-stacked js-board-dues">
-		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Due in the next day') %> <span class="js-due hide">day</span></div></li>
-		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Due in the next week') %> <span class="js-due hide">week</span></div></li>
-		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Due in the next month') %> <span class="js-due hide">month</span></div></li>
-		<li class="clearfix js-due-filter cur card-label-show h5 btn-link"><div class="navbar-btn clearfix media htruncate"><%- i18next.t('Overdue') %> <span class="js-due hide">overdue</span></div></li>
-	</ul>
-	<hr>
 	<ul class="nav nav-pills nav-stacked js-filter-conjunction">
 		<li class="clearfix js-filter-mode cur card-label-show h5 btn-link" id="js-mode-or">
 			<div class="navbar-btn clearfix media">


### PR DESCRIPTION

## Description
Time based filter moved up before label based filter for Filter Cards in Board Header

## Related Issue
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![time_based_filter](https://user-images.githubusercontent.com/17172525/35718935-ce865246-080c-11e8-92df-9e05cce85d44.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
