### PR TITLE
Fixes #1526 : While adding card in Board page via instant add card, the attachments are not added immediately issue fixed

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -3572,6 +3572,13 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                                             if (!empty($list) && isset($list[0]) && file_exists($list[0])) {
                                                 unlink($list[0]);
                                             }
+                                            $qry_val_arr = array(
+                                                $response['id']
+                                            );
+                                            $card_attachments = pg_query_params($db_lnk, 'SELECT * FROM card_attachments WHERE card_id = $1', $qry_val_arr);
+                                            while ($card_attachment = pg_fetch_assoc($card_attachments)) {
+                                                $response['card_attachments'][] = $card_attachment;
+                                            }
                                         }
                                     }
                                 }
@@ -3599,6 +3606,13 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                             $comment = '##USER_NAME## added attachment to this card ##CARD_LINK##';
                             $response_file['activity'] = insertActivity($authUser['id'], $comment, 'add_card_attachment', $foreign_ids, null, $response_file['card_attachments'][$i]['id']);
                             $i++;
+                            $qry_val_arr = array(
+                                $response['id']
+                            );
+                            $card_attachments = pg_query_params($db_lnk, 'SELECT * FROM card_attachments WHERE card_id = $1', $qry_val_arr);
+                            while ($card_attachment = pg_fetch_assoc($card_attachments)) {
+                                $response['card_attachments'][] = $card_attachment;
+                            }
                         }
                     }
                     if (isset($r_post['image_link']) && !empty($r_post['image_link'])) {
@@ -3635,6 +3649,13 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                                     $list = glob($mediadir . '.*');
                                     if (!empty($list) && isset($list[0]) && file_exists($list[0])) {
                                         unlink($list[0]);
+                                    }
+                                    $qry_val_arr = array(
+                                        $response['id']
+                                    );
+                                    $card_attachments = pg_query_params($db_lnk, 'SELECT * FROM card_attachments WHERE card_id = $1', $qry_val_arr);
+                                    while ($card_attachment = pg_fetch_assoc($card_attachments)) {
+                                        $response['card_attachments'][] = $card_attachment;
                                     }
                                 }
                             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now, while adding the card in Board page via instant add card, the attachments are shown in front of the card and when opening the created card page the attachments will show.

## Related Issue
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
