### PR TITLE
Fixes #1528 : While copying card, custom Fields from original cards are not copied issue fixed

### DIFF
--- a/client/js/templates/copy_card.jst.ejs
+++ b/client/js/templates/copy_card.jst.ejs
@@ -52,6 +52,14 @@
 					</div>
 				</div>
 		   <% } %>
+		   		<div class="form-group">
+					<div class="checkbox">
+						<input id="custom_fields" class="hide" type="checkbox" name="keep_custom_fields" value="1" checked="checked">
+						<label for="custom_fields">
+							<%- i18next.t('Custom Fields') %> 
+						</label>
+					</div>
+				</div>
 		</div>
 <%	}  %>
 		<h4> <%- i18next.t('Copy to...') %></h4>

--- a/client/locales/en_US/translation.json
+++ b/client/locales/en_US/translation.json
@@ -235,6 +235,7 @@
     "Creates users with password \"restya\" and email as empty for each repository users from GitHub.": "Creates users with password \"restya\" and email as empty for each repository users from GitHub.",
     "Custom": "Custom",
     "Custom Field": "Custom Field",
+    "Custom Fields": "Custom Fields",
     "CustomFields": "CustomFields",
     "CustomFields is our theming partner": "CustomFields is our theming partner",
     "DB Host": "DB Host",

--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -4401,6 +4401,10 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
             $is_keep_checklist = $r_post['keep_checklists'];
             unset($r_post['keep_checklists']);
         }
+        if (isset($r_post['keep_custom_fields'])) {
+            $is_keep_custom_fields = $r_post['keep_custom_fields'];
+            unset($r_post['keep_custom_fields']);
+        }
         $copied_card_id = $r_resource_vars['cards'];
         unset($r_post['copied_card_id']);
         $qry_val_arr = array(
@@ -4467,6 +4471,15 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                         $copied_card_id
                     );
                     pg_query_params($db_lnk, 'INSERT INTO cards_labels (created, modified, card_id, label_id, list_id, board_id) SELECT created, modified, $1, label_id, $2, $3 FROM cards_labels WHERE card_id = $4 ORDER BY id', $qry_val_arr);
+                }
+                if ($is_keep_custom_fields) {
+                    $qry_val_arr = array(
+                        $response['id'],
+                        $r_post['list_id'],
+                        $r_post['board_id'],
+                        $copied_card_id
+                    );
+                    pg_query_params($db_lnk, 'INSERT INTO cards_custom_fields (created, modified, card_id, custom_field_id, value,is_active,board_id,list_id) SELECT created, modified, $1, custom_field_id,value,is_active, $2, $3 FROM cards_custom_fields WHERE card_id = $4 ORDER BY id', $qry_val_arr);
                 }
                 if ($is_keep_activity) {
                     $qry_val_arr = array(


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Now, when you  copy card, custom Fields from original cards will be copied to the newly copied cards

## Related Issue
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
