### PR TITLE
Fixes #1532 : Long reply for the comments are going outside the comments area issue fixed

### DIFF
--- a/client/js/views/activity_view.js
+++ b/client/js/views/activity_view.js
@@ -49,7 +49,7 @@ App.ActivityView = Backbone.View.extend({
     }),
     template: JST['templates/activity'],
     tagName: 'li',
-    className: 'btn-block col-xs-12 js-activity activity-github-styles',
+    className: 'js-activity activity-github-styles',
     /**
      * Events
      * functions to fire on events (Mouse events, Keyboard Events, Frame/Object Events, Form Events, Drag Events, etc...)
@@ -94,9 +94,13 @@ App.ActivityView = Backbone.View.extend({
             this.$el.addClass('js-list-activity-' + this.model.attributes.id);
             if (this.model.attributes.depth !== 0) {
                 if (listing_type === '') {
+                    var column = 12 - parseInt(this.model.attributes.depth);
                     var col_offset = parseInt(this.model.attributes.depth);
+                    this.$el.addClass('col-xs-' + column);
                     this.$el.addClass('col-lg-offset-' + col_offset);
                 }
+            } else {
+                this.$el.addClass('col-xs-12');
             }
             if (!this.is_from) {
                 var filter = ($.cookie('filter') === undefined || $.cookie('filter') === 'comment') ? 1 : 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now long text reply for comments will come inside comments area

## Related Issue
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
