### PR TITLE
Fixes #1534 : While filtering cards using Filter cards option in the board header, labels needs to be ordered alphabetically issue fixed

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -690,6 +690,8 @@ App.BoardHeaderView = Backbone.View.extend({
     showFilters: function() {
         $('.js-side-bar-' + this.model.id).addClass('side-bar-large');
         var el = this.$el;
+        this.model.labels.setSortField('name', 'asc');
+        this.model.labels.sort();
         el.find('.js-setting-response').html(new App.BoardFilterView({
             model: this.model,
             labels: this.model.labels


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
 Now, while filtering cards using Filter cards option in the board header, labels are ordered alphabetically 

## Related Issue 
 No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![label_order](https://user-images.githubusercontent.com/17172525/35957119-d8a4a5c2-0cbf-11e8-80a7-230741cae044.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
