### PR TITLE
Fixes #1545 : In boards page, the doughnut chart for each boards are not updated immediately issue fixed

### DIFF
--- a/client/js/views/card_view.js
+++ b/client/js/views/card_view.js
@@ -172,8 +172,28 @@ App.CardView = Backbone.View.extend({
             patch: true,
             silent: true
         });
+        var current_board = App.boards.where({
+            id: parseInt(self.model.attributes.board_id)
+        });
+        current_board = current_board['0'];
+        var prev_list = current_board.lists.findWhere({
+            id: parseInt(previous_list_id)
+        });
+        var current_list = current_board.lists.findWhere({
+            id: parseInt(list_id)
+        });
+        var prev_list_card_count = parseInt(self.model.list.collection.board.lists.get(previous_list_id).get('card_count'));
+        var current_list_card_count = parseInt(self.model.list.collection.board.lists.get(list_id).get('card_count'));
+
         self.model.list.collection.board.lists.get(previous_list_id).cards.remove(self.model);
+        self.model.list.collection.board.lists.get(previous_list_id).set('card_count', prev_list_card_count - 1);
+        prev_list.set('card_count', prev_list_card_count - 1);
+
         self.model.list.collection.board.lists.get(list_id).cards.add(self.model);
+        self.model.list.collection.board.lists.get(list_id).set('card_count', current_list_card_count + 1);
+        current_list.set('card_count', current_list_card_count + 1);
+
+
         var attachments = self.model.list.collection.board.attachments.where({
             card_id: self.model.attributes.id
         });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Now when moving cards between list in board page,and come to boards page, the doughnut chart for board will be updated

## Related Issue
 No
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
