### PR TITLE
Fixes #1555 :  While giving link for attachments in cards, the attachment is saved issue fixed

### DIFF
--- a/client/js/templates/card.jst.ejs
+++ b/client/js/templates/card.jst.ejs
@@ -13,7 +13,7 @@
   </div>
  <%  } %> 
  <div class="clearfix">
-  <% if(!_.isEmpty(card.attachments) && card.attachments.length > 0 && !_.isEmpty(card.attachments.at(0).attributes.name) && card.attachments.at(0).attributes.name.toLowerCase().match(/\.(jpg|jpeg|png|gif)$/)){ %>
+  <% if(!_.isEmpty(card.attachments) && card.attachments.length > 0 && !_.isEmpty(card.attachments.at(0).attributes.name) && _.isEmpty(card.attachments.at(0).attributes.link) && card.attachments.at(0).attributes.name.toLowerCase().match(/\.(jpg|jpeg|png|gif)$/)){ %>
 	  <div class="clearfix js-card-attachment-image navbar-btn <% if(!_.isEmpty(card.collection) && !card.list.collection.board.attributes.is_show_image_front_of_card){ %> hide <% } %>">
 		<%
 			var img_src = card.showImage('CardAttachment',  card.attachments.at(0).attributes.id, 'large_thumb' );

--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -3619,21 +3619,8 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                     }
                     if (isset($r_post['image_link']) && !empty($r_post['image_link'])) {
                         $sql = true;
-                        $attachment_url_host = parse_url($r_post['image_link'], PHP_URL_HOST);
-                        $url_hosts = array(
-                            'docs.google.com',
-                            'www.dropbox.com',
-                            'github.com'
-                        );
-                        if (in_array($attachment_url_host, $url_hosts)) {
-                            $r_post['name'] = $r_post['link'] = $r_post['image_link'];
-                            $r_post['path'] = '';
-                        } else {
-                            $filename = curlExecute($r_post['image_link'], 'get', $mediadir, 'image');
-                            $r_post['name'] = $filename['file_name'];
-                            $r_post['link'] = $r_post['image_link'];
-                            $r_post['path'] = $save_path . '/' . $r_post['name'];
-                        }
+                        $r_post['name'] = $r_post['link'] = $r_post['image_link'];
+                        $r_post['path'] = '';
                         unset($r_post['image_link']);
                         if (!empty($sql)) {
                             $post = getbindValues($table_name, $r_post);
@@ -4026,21 +4013,8 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                 }
             } else {
                 $sql = true;
-                $attachment_url_host = parse_url($r_post['image_link'], PHP_URL_HOST);
-                $url_hosts = array(
-                    'docs.google.com',
-                    'www.dropbox.com',
-                    'github.com'
-                );
-                if (in_array($attachment_url_host, $url_hosts)) {
-                    $r_post['name'] = $r_post['link'] = $r_post['image_link'];
-                    $r_post['path'] = '';
-                } else {
-                    $filename = curlExecute($r_post['image_link'], 'get', $mediadir, 'image');
-                    $r_post['name'] = $filename['file_name'];
-                    $r_post['link'] = $r_post['image_link'];
-                    $r_post['path'] = $save_path . '/' . $r_post['name'];
-                }
+                $r_post['name'] = $r_post['link'] = $r_post['image_link'];
+                $r_post['path'] = '';
                 unset($r_post['image_link']);
                 if (!empty($sql)) {
                     $post = getbindValues($table_name, $r_post);


### PR DESCRIPTION
## Description
 Now, when you give attachment URL to the card attachments, the attachments  are not downloaded and represented in link format 

## Related Issue
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
