### PR TITLE
Fixes #1591 : Cannot able to view other user's cards in user/id/cards page issue fixed

### DIFF
--- a/client/js/application.js
+++ b/client/js/application.js
@@ -535,7 +535,7 @@ var AppRouter = Backbone.Router.extend({
     user_view_type: function(id, type) {
         var Auth_check = JSON.parse($.cookie('auth'));
         if ($.cookie('auth') !== null) {
-            if (Auth_check.user.id == id || Auth_check.user.role_id == '1') {
+            if (Auth_check.user.id == id || Auth_check.user.role_id == '1' || type === 'cards' || type === "profile") {
                 new App.ApplicationView({
                     model: 'user_view',
                     'id': id,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Now normal users can see other users cards in user/id/cards page

## Related Issue
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
