### PR TITLE
Fixes #1357 : Search and sorting of members for a card issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -2860,6 +2860,8 @@ App.ModalCardView = Backbone.View.extend({
         if (q !== '') {
             var filtered_users = this.model.list.collection.board.board_users.search(q);
             var users = new App.UserCollection();
+            users.setSortField('username', 'asc');
+            users.sort();
             if (!_.isEmpty(filtered_users._wrapped)) {
                 $.unique(filtered_users._wrapped);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now, when you search for the user in add member option of modal card, the result names are ordered alpabhetically

## Related Issue
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
