### PR TITLE
Fixes #1649: Dates are not displayed - issue fixed

### DIFF
--- a/client/js/templates/admin_board_view.jst.ejs
+++ b/client/js/templates/admin_board_view.jst.ejs
@@ -169,14 +169,15 @@
 </td> 
 <td class="text-center">
     <a href="#" class="js-no-action">
-		<% var created = parse_date(board.attributes.created, authuser); %>
-		<abbr class="" title="<%- created.datetime %>"><%- created.timeago %></abbr>
+		<% var created = parse_date(board.attributes.created, authuser, 'js-timeago1-admin-board-view-'+board.attributes.id); %>
+		<span class="js-timeago1-admin-board-view-<%- board.attributes.id %>"></span>
 	</a>
+	
 </td>
 <td class="text-center">
     <a href="#" class="js-no-action">
-	<% var modified = parse_date(board.attributes.modified, authuser); %>
-	<abbr class="" title="<%-modified.datetime%>"><%- modified.timeago %></abbr>
+		<% var modified = parse_date(board.attributes.modified, authuser, 'js-timeago2-admin-board-view-'+board.attributes.id); %>
+		<span class="js-timeago2-admin-board-view-<%- board.attributes.id %>"></span>
 	</a>
 </td>
 <td class="text-center">

--- a/client/js/templates/attachment.jst.ejs
+++ b/client/js/templates/attachment.jst.ejs
@@ -47,8 +47,8 @@
 			<a target="_blank" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- attachment.attributes.name %>">
 		<% } %>
 			<span class="htruncate col-xs-12 btn-block"><%- attachment.attributes.name %></span><span class="show btn-block col-xs-12"><%- i18next.t('Added') %> <small class="text-muted">
-			<% var created = parse_date(attachment.attributes.created, authuser); %>
-			<abbr class="" title="<%- created.datetime %>"><%- created.timeago %></abbr>
+			<% var created = parse_date(attachment.attributes.created, authuser, 'js-timeago-attachment1-'+attachment.attributes.id); %>
+			<span class="js-timeago-attachment1-<%- attachment.attributes.id %>"></span>
 			</small></span></a>
 		<% } else if(!_.isEmpty(attachment.attributes.link)){ %>
 			<%   
@@ -59,8 +59,8 @@
 				<a target="_blank" href="<%= attachment.attributes.link %>" title="<%- attachment.attributes.link %>">
 			<% } %>
 				<span class="htruncate col-xs-12 btn-block"><%- attachment.attributes.link %></span><span class="show btn-block col-xs-12"><%- i18next.t('Added') %> <small class="text-muted">
-				<% var created = parse_date(attachment.attributes.created, authuser); %>
-				<abbr class="" title="<%- created.datetime %>"><%- created.timeago %></abbr>
+				<% var created = parse_date(attachment.attributes.created, authuser, 'js-timeago-attachment2-'+attachment.attributes.id); %>
+				<span class="js-timeago-attachment2-<%- attachment.attributes.id %>"></span>
 				</small></span>
 			</a>
 		<% } %>

--- a/client/js/templates/card_attachment.jst.ejs
+++ b/client/js/templates/card_attachment.jst.ejs
@@ -45,8 +45,8 @@
 		<a target="_blank" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- attachment.attributes.name %>"><span class="show htruncate col-xs-11 nav"><%- attachment.attributes.name %></span>
 	<% } %>
 		<span class="show btn-block col-xs-12"><%- i18next.t('Added') %> <small class="text-muted">
-		<% var created = parse_date(attachment.attributes.created, authuser); %>
-		<abbr class="" title="<%- created.datetime %>"><%- created.timeago %></abbr>
+		<% var created = parse_date(attachment.attributes.created, authuser, 'js-timeago-card-attachment1-'+attachment.attributes.id); %>
+		<span class="js-timeago-card-attachment1-<%- attachment.attributes.id %>"></span>
 		</small></span></a>
 <% } else if(!_.isEmpty(attachment.attributes.link)){ %>
 	<% 
@@ -57,8 +57,8 @@
 		<a target="_blank" href="<%= attachment.attributes.link %>" title="<%- attachment.attributes.link %>">
 	<% } %>
 			<span class="show htruncate col-xs-11 nav"><%- attachment.attributes.link %></span><span class="show btn-block col-xs-12"><%- i18next.t('Added') %> <small class="text-muted">
-			<% var created = parse_date(attachment.attributes.created, authuser); %>
-			<abbr class="" title="<%- created.datetime %>"><%- created.timeago %></abbr>
+			<% var created = parse_date(attachment.attributes.created, authuser, 'js-timeago-card-attachment2-'+attachment.attributes.id); %>
+		<span class="js-timeago-card-attachment2-<%- attachment.attributes.id %>"></span>
 			</small></span>
 		</a>
 <% } %>

--- a/client/js/templates/user.jst.ejs
+++ b/client/js/templates/user.jst.ejs
@@ -71,8 +71,8 @@
 </td>
 <td class="text-center">
     <% if(user.get('last_login_date') !== null){ %>
-	<% var last_login_date = parse_date(user.get('last_login_date'), authuser); %>
-	<abbr class="" title="<%- last_login_date.datetime %>"><%- last_login_date.timeago %></abbr>
+	<% var last_login_date = parse_date(user.get('last_login_date'), authuser, 'js-timeago-user-'+user.attributes.id); %>
+	<span class="js-timeago-user-<%- user.attributes.id %>"></span>
 	<%}else{%>-<%}%>
 	
 </td>
@@ -84,8 +84,8 @@
 	<% if(!_.isEmpty(user.attributes.login_city_name)){ %> <%- user.attributes.login_city_name %><% } %>
 </td>
 <td class="text-center">
-	<% var created = parse_date(user.get('created'), authuser); %>
-    <abbr class="" title="<%- created.datetime %>"><%- created.timeago %></abbr>
+	<% var created = parse_date(user.get('created'), authuser, 'js-timeago-user2-'+user.attributes.id); %>
+	<span class="js-timeago-user2-<%- user.attributes.id %>"></span>
 </td> 
 <td class="text-center">
 	<span class="show"><%- user.attributes.registered_ip%></span> 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Dates are missing due to missing one class param in parse_date function. Now the issue is fixed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with our local, and now admin page user's listing having last logged date and fixed on other pages also. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
