### PR TITLE
Fixes #1609: php installation related issue fixed

### DIFF
--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -743,7 +743,7 @@
 						echo "Installing PHP..."
 						rpm -Uvh "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.noarch.rpm"
 						rpm -Uvh "https://mirror.webtatic.com/yum/el${OS_VERSION}/webtatic-release.rpm"
-						yum install php70w php70w-opcache
+						yum install -y php70w php70w-opcache
 						if [ $? != 0 ]
 						then
 							echo "php installation failed with error code 20"
@@ -858,7 +858,7 @@
 				php -m | grep xml
 				if [ "$?" -gt 0 ]; then
 					echo "Installing xml..."
-					yum install php70w-xml
+					yum install -y php70w-xml
 					if [ $? != 0 ]
 					then
 						echo "xml installation failed with error code 57"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

PHP installation is breaking due to '-y' is not available

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Now -y is added and working on CentOS

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
