### PR TITLE
Fixes #1685: Activities producing lots of PHP warnings - issue fixed

### DIFF
--- a/server/php/libs/core.php
+++ b/server/php/libs/core.php
@@ -387,11 +387,15 @@ function insertActivity($user_id, $comment, $type, $foreign_ids = array() , $rev
 function getRevisiondifference($from_text, $to_text)
 {
     // limit input
-    if (!empty($from_text)) {
+    if (!empty($from_text) && is_string($from_text)) {
         $from_text = substr($from_text, 0, 1024 * 100);
+    } else {
+        return false;
     }
-    if (!empty($to_text)) {
+    if (!empty($to_text) && is_string($to_text)) {
         $to_text = substr($to_text, 0, 1024 * 100);
+    } else {
+        return false;
     }
     $granularity = 2; // 0: Paragraph/lines, 1: Sentence, 2: Word, 3: Character
     $granularityStacks = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Activities producing lots of PHP warnings due to passing array instead of string. Now the issue is fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on our local server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
