### PR TITLE
 Fixes #1305: don't delete all messages when using imap.php 

### DIFF
--- a/server/php/shell/imap.php
+++ b/server/php/shell/imap.php
@@ -30,230 +30,231 @@ $connection = imap_open('{' . IMAP_HOST . ':' . IMAP_PORT . '/imap/' . $is_ssl .
 if (!$connection) {
     return;
 }
-$message_count = imap_num_msg($connection);
-for ($counter = 1; $counter <= $message_count; $counter++) {
-    $header = imap_header($connection, $counter);
-    foreach ($header->to as $to) {
-        $mail = explode('+', $to->mailbox);
-        // Email format for board - board+##board_id##+hash@restya.com
-        // Email format for card  - board+##board_id##+##card_id##+hash@restya.com
-        // Check to email address contains atleast one "+" symbol
-        if (count($mail) > 1) {
-            // Fetch email body
-            $s = imap_fetchstructure($connection, $counter);
-            if (!$s->parts) { // simple
-                $body = imapBodyDecode($connection, $counter, $s, 0); // pass 0 as part-number
-                
-            } else { // multipart: cycle through each part
-                foreach ($s->parts as $partno => $p) {
-                    $body_data[] = imapBodyDecode($connection, $counter, $p, $partno + 1);
-                }
-                if ($body_data) {
-                    if ($body_data[0] && is_array($body_data[0])) {
-                        $body = $body_data[0][0];
-                    } else {
-                        $body = $body_data[0];
+$emails = imap_search($connection,'UNSEEN');
+if(!empty($emails)) {
+    foreach($emails as $key => $counter) {
+        $header = imap_header($connection, $counter);
+        foreach ($header->to as $to) {
+            $mail = explode('+', $to->mailbox);
+            // Email format for board - board+##board_id##+hash@restya.com
+            // Email format for card  - board+##board_id##+##card_id##+hash@restya.com
+            // Check to email address contains atleast one "+" symbol
+            if (count($mail) > 1) {
+                // Fetch email body
+                $s = imap_fetchstructure($connection, $counter);
+                if (empty($s->parts)) { // simple
+                    $body = imapBodyDecode($connection, $counter, $s, 0); // pass 0 as part-number
+                } else { // multipart: cycle through each part
+                    foreach ($s->parts as $partno => $p) {
+                        $body_data[] = imapBodyDecode($connection, $counter, $p, $partno + 1);
                     }
-                }
-            }
-            $board_id = $mail[1];
-            $card_id = '';
-            $hash = $mail[2];
-            if (count($mail) > 3) {
-                $card_id = $mail[2];
-                $hash = $mail[3];
-            }
-            // Check email hash with generated hash
-            if ($hash == md5(SECURITYSALT . $board_id . $card_id)) {
-                $condition = array(
-                    $board_id
-                );
-                // Check from email is a member/owner in board
-                $board_query = pg_query_params($db_lnk, 'SELECT default_email_list_id, is_default_email_position_as_bottom, user_id FROM boards_users_listing WHERE board_id = $1', $condition);
-                $board = pg_fetch_assoc($board_query);
-                if (!empty($board)) {
-                    // To email address is for board then insert the email as new card
-                    if (empty($card_id)) {
-                        $str = 'coalesce(MAX(position), 0)';
-                        if (empty($board['is_default_email_position_as_bottom'])) {
-                            $str = 'coalesce(MIN(position), 0)';
-                        }
-                        $list_id = $board['default_email_list_id'];
-                        $val_arr = array(
-                            $board_id,
-                            $list_id
-                        );
-                        // Select minimum/maximum card position based on email to board settings
-                        $card_query = pg_query_params('SELECT ' . $str . ' as position FROM cards WHERE board_id = $1 AND list_id = $2', $val_arr);
-                        $card = pg_fetch_assoc($card_query);
-                        $position = empty($card['position']) ? 1 : (!empty($board['is_default_email_position_as_bottom'])) ? $card['position'] + 1 : ($card['position'] / 2);
-                        // Fetch email header
-                        $title = imap_utf8($header->subject);
-                        $val_arr = array(
-                            $board_id,
-                            $list_id,
-                            $title,
-                            $body,
-                            $position,
-                            $board['user_id']
-                        );
-                        // Insert card in default list id and position as selected in email to board settings
-                        $card_query = pg_query_params($db_lnk, 'INSERT INTO cards (created, modified, board_id, list_id, name, description, position, user_id) VALUES (now(), now(), $1, $2, $3, $4, $5, $6) RETURNING id', $val_arr);
-                        $card = pg_fetch_assoc($card_query);
-                        $card_id = $card['id'];
-                        // Inserting activities for the inserted card
-                        $val_arr = array(
-                            $card_id,
-                            $board['user_id'],
-                            $list_id,
-                            $board_id,
-                            'add_card',
-                            '##USER_NAME## added card ##CARD_LINK## to list "' . $list['name'] . '".'
-                        );
-                        $activity_res = pg_query_params($db_lnk, 'INSERT INTO activities (created, modified, card_id, user_id, list_id, board_id, type, comment) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
-                    } else {
-                        // To email address is for specific card then insert the email as card comment
-                        $val_arr = array(
-                            $card_id
-                        );
-                        // Fetching list_id to update in card comment
-                        $card_query = pg_query_params('SELECT list_id FROM cards WHERE id = $1', $val_arr);
-                        $card = pg_fetch_assoc($card_query);
-                        $list_id = $card['list_id'];
-                        $val_arr = array(
-                            $card_id,
-                            $board['user_id'],
-                            $list_id,
-                            $board_id,
-                            'add_comment',
-                            $body
-                        );
-                        // Insert email content as comment in respective card
-                        $activity_res = pg_query_params($db_lnk, 'INSERT INTO activities (created, modified, card_id, user_id, list_id, board_id, type, comment) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
-                        $activity = pg_fetch_assoc($activity_res);
-                        if (!empty($activity)) {
-                            $id_converted = base_convert($activity['id'], 10, 36);
-                            $materialized_path = sprintf("%08s", $id_converted);
-                            $path = 'P' . $activity['id'];
-                            $depth = 0;
-                            $root = $activity['id'];
-                            $freshness_ts = $created;
-                            $qry_val_arr = array(
-                                $materialized_path,
-                                $path,
-                                $depth,
-                                $root,
-                                $freshness_ts,
-                                $activity['id']
-                            );
-                            pg_query_params($db_lnk, 'UPDATE activities SET materialized_path = $1, path = $2, depth = $3, root = $4, freshness_ts = $5 WHERE id = $6', $qry_val_arr);
-                            $qry_val_arr = array(
-                                $freshness_ts,
-                                $root
-                            );
-                            pg_query_params($db_lnk, 'UPDATE activities SET freshness_ts = $1 WHERE root = $2', $qry_val_arr);
+                    if ($body_data) {
+                        if ($body_data[0] && is_array($body_data[0])) {
+                            $body = $body_data[0][0];
+                        } else {
+                            $body = $body_data[0];
                         }
                     }
-                    // Fetching email structure to get the attachments
-                    $structure = imap_fetchstructure($connection, $header->Msgno);
-                    $attachments = array();
-                    if (isset($structure->parts) && count($structure->parts)) {
-                        $i = 0;
-                        $file_attachments = false;
-                        foreach ($structure->parts as $partno0 => $p) {
-                            $attachments[$i] = array(
-                                'is_attachment' => false,
-                                'filename' => '',
-                                'name' => '',
-                                'attachment' => '',
-                            );
-                            if (isset($structure->parts[$i]->bytes)) {
-                                $attachments[$i]['filesize'] = $structure->parts[$i]->bytes;
+                }
+                $board_id = $mail[1];
+                $card_id = '';
+                $hash = $mail[2];
+                if (count($mail) > 3) {
+                    $card_id = $mail[2];
+                    $hash = $mail[3];
+                }
+                // Check email hash with generated hash
+                if ($hash == md5(SECURITYSALT . $board_id . $card_id)) {
+                    $condition = array(
+                        $board_id
+                    );
+                    // Check from email is a member/owner in board
+                    $board_query = pg_query_params($db_lnk, 'SELECT default_email_list_id, is_default_email_position_as_bottom, user_id FROM boards_users_listing WHERE board_id = $1', $condition);
+                    $board = pg_fetch_assoc($board_query);
+                    if (!empty($board)) {
+                        // To email address is for board then insert the email as new card
+                        if (empty($card_id)) {
+                            $str = 'coalesce(MAX(position), 0)';
+                            if (empty($board['is_default_email_position_as_bottom'])) {
+                                $str = 'coalesce(MIN(position), 0)';
                             }
-                            //### Tmobile & metropcs
-                            if (!empty($structure->parts[$i]->id)) {
-                                if (preg_match('/</i', $structure->parts[$i]->id) && preg_match('/>/i', $structure->parts[$i]->id)) {
-                                    foreach ($structure->parts[$i]->parameters as $param) {
-                                        if (strtolower($param->attribute) == 'name') {
-                                            $attachments[$i]['is_attachment'] = true;
-                                            $attachments[$i]['name'] = $param->value;
-                                            $attachments[$i]['filename'] = $param->value;
+                            $list_id = $board['default_email_list_id'];
+                            $val_arr = array(
+                                $board_id,
+                                $list_id
+                            );
+                            // Select minimum/maximum card position based on email to board settings
+                            $card_query = pg_query_params('SELECT ' . $str . ' as position FROM cards WHERE board_id = $1 AND list_id = $2', $val_arr);
+                            $card = pg_fetch_assoc($card_query);
+                            $position = empty($card['position']) ? 1 : (!empty($board['is_default_email_position_as_bottom'])) ? $card['position'] + 1 : ($card['position'] / 2);
+                            // Fetch email header
+                            $title = imap_utf8($header->subject);
+                            $val_arr = array(
+                                $board_id,
+                                $list_id,
+                                $title,
+                                $body,
+                                $position,
+                                $board['user_id']
+                            );
+                            // Insert card in default list id and position as selected in email to board settings
+                            $card_query = pg_query_params($db_lnk, 'INSERT INTO cards (created, modified, board_id, list_id, name, description, position, user_id) VALUES (now(), now(), $1, $2, $3, $4, $5, $6) RETURNING id', $val_arr);
+                            $card = pg_fetch_assoc($card_query);
+                            $card_id = $card['id'];
+                            // Inserting activities for the inserted card
+                            $val_arr = array(
+                                $card_id,
+                                $board['user_id'],
+                                $list_id,
+                                $board_id,
+                                'add_card',
+                                '##USER_NAME## added card ##CARD_LINK## to list ##LIST_NAME##.'
+                            );
+                            $activity_res = pg_query_params($db_lnk, 'INSERT INTO activities (created, modified, card_id, user_id, list_id, board_id, type, comment) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
+                        } else {
+                            // To email address is for specific card then insert the email as card comment
+                            $val_arr = array(
+                                $card_id
+                            );
+                            // Fetching list_id to update in card comment
+                            $card_query = pg_query_params('SELECT list_id FROM cards WHERE id = $1', $val_arr);
+                            $card = pg_fetch_assoc($card_query);
+                            $list_id = $card['list_id'];
+                            $val_arr = array(
+                                $card_id,
+                                $board['user_id'],
+                                $list_id,
+                                $board_id,
+                                'add_comment',
+                                $body
+                            );
+                            // Insert email content as comment in respective card
+                            $activity_res = pg_query_params($db_lnk, 'INSERT INTO activities (created, modified, card_id, user_id, list_id, board_id, type, comment) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
+                            $activity = pg_fetch_assoc($activity_res);
+                            if (!empty($activity)) {
+                                $id_converted = base_convert($activity['id'], 10, 36);
+                                $materialized_path = sprintf("%08s", $id_converted);
+                                $path = 'P' . $activity['id'];
+                                $depth = 0;
+                                $root = $activity['id'];
+                                $freshness_ts = $created;
+                                $qry_val_arr = array(
+                                    $materialized_path,
+                                    $path,
+                                    $depth,
+                                    $root,
+                                    $freshness_ts,
+                                    $activity['id']
+                                );
+                                pg_query_params($db_lnk, 'UPDATE activities SET materialized_path = $1, path = $2, depth = $3, root = $4, freshness_ts = $5 WHERE id = $6', $qry_val_arr);
+                                $qry_val_arr = array(
+                                    $freshness_ts,
+                                    $root
+                                );
+                                pg_query_params($db_lnk, 'UPDATE activities SET freshness_ts = $1 WHERE root = $2', $qry_val_arr);
+                            }
+                        }
+                        // Fetching email structure to get the attachments
+                        $structure = imap_fetchstructure($connection, $header->Msgno);
+                        $attachments = array();
+                        if (isset($structure->parts) && count($structure->parts)) {
+                            $i = 0;
+                            $file_attachments = false;
+                            foreach ($structure->parts as $partno0 => $p) {
+                                $attachments[$i] = array(
+                                    'is_attachment' => false,
+                                    'filename' => '',
+                                    'name' => '',
+                                    'attachment' => '',
+                                );
+                                if (isset($structure->parts[$i]->bytes)) {
+                                    $attachments[$i]['filesize'] = $structure->parts[$i]->bytes;
+                                }
+                                //### Tmobile & metropcs
+                                if (!empty($structure->parts[$i]->id)) {
+                                    if (preg_match('/</i', $structure->parts[$i]->id) && preg_match('/>/i', $structure->parts[$i]->id)) {
+                                        foreach ($structure->parts[$i]->parameters as $param) {
+                                            if (strtolower($param->attribute) == 'name') {
+                                                $attachments[$i]['is_attachment'] = true;
+                                                $attachments[$i]['name'] = $param->value;
+                                                $attachments[$i]['filename'] = $param->value;
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            // Setting attachment filename
-                            if ($structure->parts[$i]->ifdparameters) {
-                                foreach ($structure->parts[$i]->dparameters as $object) {
-                                    if (strtolower($object->attribute) == 'filename') {
-                                        if (!preg_match('/tmobile/i', strtolower($object->value)) && !preg_match('/dottedline/i', strtolower($object->value))) {
-                                            $attachments[$i]['is_attachment'] = true;
-                                            $attachments[$i]['filename'] = $object->value;
+                                // Setting attachment filename
+                                if ($structure->parts[$i]->ifdparameters) {
+                                    foreach ($structure->parts[$i]->dparameters as $object) {
+                                        if (strtolower($object->attribute) == 'filename') {
+                                            if (!preg_match('/tmobile/i', strtolower($object->value)) && !preg_match('/dottedline/i', strtolower($object->value))) {
+                                                $attachments[$i]['is_attachment'] = true;
+                                                $attachments[$i]['filename'] = $object->value;
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            // Setting attachment name
-                            if ($structure->parts[$i]->ifparameters) {
-                                foreach ($structure->parts[$i]->parameters as $object) {
-                                    if (strtolower($object->attribute) == 'name') {
-                                        $attachments[$i]['is_attachment'] = true;
-                                        $attachments[$i]['name'] = $object->value;
+                                // Setting attachment name
+                                if ($structure->parts[$i]->ifparameters) {
+                                    foreach ($structure->parts[$i]->parameters as $object) {
+                                        if (strtolower($object->attribute) == 'name') {
+                                            $attachments[$i]['is_attachment'] = true;
+                                            $attachments[$i]['name'] = $object->value;
+                                        }
                                     }
                                 }
-                            }
-                            // Decoding the attachment content based on encoding format
-                            if ($attachments[$i]['is_attachment']) {
-                                $attachments[$i]['attachment'] = imap_fetchbody($connection, $header->Msgno, $i + 1);
-                                if ($structure->parts[$i]->encoding == 3) { // 3 = BASE64
-                                    $attachments[$i]['attachment'] = base64_decode($attachments[$i]['attachment']);
-                                } elseif ($structure->parts[$i]->encoding == 4) { // 4 = QUOTED-PRINTABLE
-                                    $attachments[$i]['attachment'] = quoted_printable_decode($attachments[$i]['attachment']);
+                                // Decoding the attachment content based on encoding format
+                                if ($attachments[$i]['is_attachment']) {
+                                    $attachments[$i]['attachment'] = imap_fetchbody($connection, $header->Msgno, $i + 1);
+                                    if ($structure->parts[$i]->encoding == 3) { // 3 = BASE64
+                                        $attachments[$i]['attachment'] = base64_decode($attachments[$i]['attachment']);
+                                    } elseif ($structure->parts[$i]->encoding == 4) { // 4 = QUOTED-PRINTABLE
+                                        $attachments[$i]['attachment'] = quoted_printable_decode($attachments[$i]['attachment']);
+                                    }
                                 }
-                            }
-                            if ($attachments[$i]['is_attachment'] === true) {
-                                // Generating filename with time to avoid duplicate filename for same card
-                                $file_attachments = true;
-                                $filename = date('Y_m_d', time()) . '_at_' . date('H_i_s', time()) . '_' . $attachments[$i]['filename'];
-                                $save_path = 'media' . DIRECTORY_SEPARATOR . 'Card' . DIRECTORY_SEPARATOR . $card_id;
-                                $mediadir = APP_PATH . DIRECTORY_SEPARATOR . $save_path;
-                                if (!file_exists($mediadir)) {
-                                    mkdir($mediadir, 0777, true);
+                                if ($attachments[$i]['is_attachment'] === true) {
+                                    // Generating filename with time to avoid duplicate filename for same card
+                                    $file_attachments = true;
+                                    $filename = date('Y_m_d', time()) . '_at_' . date('H_i_s', time()) . '_' . $attachments[$i]['filename'];
+                                    $save_path = 'media' . DIRECTORY_SEPARATOR . 'Card' . DIRECTORY_SEPARATOR . $card_id;
+                                    $mediadir = APP_PATH . DIRECTORY_SEPARATOR . $save_path;
+                                    if (!file_exists($mediadir)) {
+                                        mkdir($mediadir, 0777, true);
+                                    }
+                                    // Saving attachment content in file
+                                    $fh = fopen($mediadir . DIRECTORY_SEPARATOR . $filename, 'x+');
+                                    fputs($fh, $attachments[$i]['attachment']);
+                                    fclose($fh);
+                                    $val_arr = array(
+                                        $card_id,
+                                        $filename,
+                                        $save_path . '/' . $filename,
+                                        $list_id,
+                                        $board_id,
+                                        strtolower('image/' . $structure->parts[1]->subtype)
+                                    );
+                                    // Inserting attachments for the card
+                                    pg_query_params($db_lnk, 'INSERT INTO card_attachments (created, modified, card_id, name, path, list_id , board_id, mimetype) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
+                                    // Inserting activities for the inserted attachment
+                                    $val_arr = array(
+                                        $card_id,
+                                        $board['user_id'],
+                                        $list_id,
+                                        $board_id,
+                                        'add_card_attachment',
+                                        '##USER_NAME## added attachment to this card ##CARD_LINK##'
+                                    );
+                                    $activity_res = pg_query_params($db_lnk, 'INSERT INTO activities (created, modified, card_id, user_id, list_id, board_id, type, comment) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
                                 }
-                                // Saving attachment content in file
-                                $fh = fopen($mediadir . DIRECTORY_SEPARATOR . $filename, 'x+');
-                                fputs($fh, $attachments[$i]['attachment']);
-                                fclose($fh);
-                                $val_arr = array(
-                                    $card_id,
-                                    $filename,
-                                    $save_path . '/' . $filename,
-                                    $list_id,
-                                    $board_id,
-                                    strtolower('image/' . $structure->parts[1]->subtype)
-                                );
-                                // Inserting attachments for the card
-                                pg_query_params($db_lnk, 'INSERT INTO card_attachments (created, modified, card_id, name, path, list_id , board_id, mimetype) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
-                                // Inserting activities for the inserted attachment
-                                $val_arr = array(
-                                    $card_id,
-                                    $board['user_id'],
-                                    $list_id,
-                                    $board_id,
-                                    'add_card_attachment',
-                                    '##USER_NAME## added attachment to this card ##CARD_LINK##'
-                                );
-                                $activity_res = pg_query_params($db_lnk, 'INSERT INTO activities (created, modified, card_id, user_id, list_id, board_id, type, comment) VALUES (now(), now(), $1, $2, $3, $4, $5, $6)', $val_arr);
+                                $i++;
                             }
-                            $i++;
                         }
                     }
                 }
             }
         }
+        // Set Seen flag to the email
+        imap_setflag_full($connection, $counter, "\\Seen \\Flagged", ST_UID);
     }
-    // Deleting the email
-    imap_delete($connection, trim($header->Msgno));
 }
 // Closing the imap connection
 imap_expunge($connection);
@@ -289,9 +290,8 @@ function imapBodyDecode($mbox, $mid, $p, $partno)
         $message.= $data . "\n\n";
     }
     // SUBPART RECURSION
-    if ($p->parts) {
+    if (!empty($p->parts)) {
         foreach ($p->parts as $partno0 => $p2) $message[] = imapBodyDecode($mbox, $mid, $p2, $partno . '.' . ($partno0 + 1)); // 1.2, 1.2.1, etc.
-        
     }
     return $message;
 }

--- a/server/php/shell/imap.php
+++ b/server/php/shell/imap.php
@@ -30,9 +30,9 @@ $connection = imap_open('{' . IMAP_HOST . ':' . IMAP_PORT . '/imap/' . $is_ssl .
 if (!$connection) {
     return;
 }
-$emails = imap_search($connection,'UNSEEN');
-if(!empty($emails)) {
-    foreach($emails as $key => $counter) {
+$emails = imap_search($connection, 'UNSEEN');
+if (!empty($emails)) {
+    foreach ($emails as $key => $counter) {
         $header = imap_header($connection, $counter);
         foreach ($header->to as $to) {
             $mail = explode('+', $to->mailbox);
@@ -44,6 +44,7 @@ if(!empty($emails)) {
                 $s = imap_fetchstructure($connection, $counter);
                 if (empty($s->parts)) { // simple
                     $body = imapBodyDecode($connection, $counter, $s, 0); // pass 0 as part-number
+                    
                 } else { // multipart: cycle through each part
                     foreach ($s->parts as $partno => $p) {
                         $body_data[] = imapBodyDecode($connection, $counter, $p, $partno + 1);
@@ -292,6 +293,7 @@ function imapBodyDecode($mbox, $mid, $p, $partno)
     // SUBPART RECURSION
     if (!empty($p->parts)) {
         foreach ($p->parts as $partno0 => $p2) $message[] = imapBodyDecode($mbox, $mid, $p2, $partno . '.' . ($partno0 + 1)); // 1.2, 1.2.1, etc.
+        
     }
     return $message;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running imap.php I'd like to see all mails non related with restyaboard on the same place. So no need to delete all messages. Now the issue is fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on our local server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.