### PR TITLE
Fixes #1736 : Rarely after editing and saving card description, the card description is not shown in modal card issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -874,7 +874,7 @@ App.ModalCardView = Backbone.View.extend({
                 this.$el.find('#cardDescriptionEditForm').removeClass('hide').show();
             } else {
                 $('.error-msg').remove();
-                $('.js-show-card-desc').show();
+                $('.js-show-card-desc').next().show();
                 $('#cardDescriptionEditForm').hide();
                 validation = true;
             }


### PR DESCRIPTION
## Description
 After editing card description, the changed description will be shown in modal card

## Related Issue
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
