### PR TITLE
Fixes #1744 : Move all cards in this list not moving all cards of the list to target list without page refreshing issue fixed

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -747,18 +747,13 @@ App.ListView = Backbone.View.extend({
         });
         this.model.cards.set(copied_cards);
         var view_card = $('#js-card-listing-' + move_list_id);
-        var i = 1;
         _.each(copied_cards, function(copied_card) {
             var options = {
-                silent: true
+                silent: false
             };
-            if (i === copied_cards.length) {
-                options.silent = false;
-            }
             self.model.collection.board.cards.get(copied_card.id).set({
                 list_id: move_list_id
             }, options);
-            i++;
         });
         var attachments = this.model.collection.board.attachments.where({
             list_id: this.model.id


### PR DESCRIPTION
## Description
Now all cards in the list will move to target list without page refreshing 

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
