### PR TITLE
Fixes #1758 : mcrypt_create_iv function deprecated issue in PHP 7.1 version issue fixed

### DIFF
--- a/server/php/libs/vendors/OAuth2/ResponseType/AccessToken.php
+++ b/server/php/libs/vendors/OAuth2/ResponseType/AccessToken.php
@@ -122,9 +122,9 @@ class AccessToken implements AccessTokenInterface
     protected function generateAccessToken()
     {
         $tokenLen = 40;
-        if (function_exists('mcrypt_create_iv')) {
+        /*if (function_exists('mcrypt_create_iv')) {
             $randomData = mcrypt_create_iv(100, MCRYPT_DEV_URANDOM);
-        } else if (function_exists('openssl_random_pseudo_bytes')) {
+        } else */if (function_exists('openssl_random_pseudo_bytes')) {
             $randomData = openssl_random_pseudo_bytes(100);
         } else if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
             $randomData = file_get_contents('/dev/urandom', false, null, 0, 100) . uniqid(mt_rand(), true);


### PR DESCRIPTION
## Description
mcrypt_create_iv function deprecated issue in PHP 7.1 version issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
