### PR TITLE
FIxes #1812 : After removing register option from guest user role, users can be able to register by giving direct link of register page to the browser  issue fixed

### DIFF
--- a/client/js/views/application_view.js
+++ b/client/js/views/application_view.js
@@ -563,10 +563,19 @@ App.ApplicationView = Backbone.View.extend({
                 changeTitle(i18next.t('Register'));
                 $('.company').removeClass('hide');
                 var User = new App.User();
-                this.pageView = new App.RegisterView({
-                    model: User
-                });
-                $('#content').html(this.pageView.el);
+                if (!_.isEmpty(role_links.where({
+                        slug: 'users_register'
+                    }))) {
+                    this.pageView = new App.RegisterView({
+                        model: User
+                    });
+                    $('#content').html(this.pageView.el);
+                } else {
+                    app.navigate('#/users/login', {
+                        trigger: true,
+                        replace: true
+                    });
+                }
             } else if (page.model == 'login') {
                 changeTitle(i18next.t('Login'));
                 $('.company').removeClass('hide');


### PR DESCRIPTION
## Description
 Now, if the register option is not allowed for the guest user role, then if we directly give the register link to the browser, it will redirect to login page

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
