### PR TITLE
FIxes #1821 : when the admin changes the options for auto subscribe to board and card, when we create the board, the auto subscribe to the board and card is set to the default value issue fixed

### DIFF
--- a/server/php/libs/core.php
+++ b/server/php/libs/core.php
@@ -978,7 +978,7 @@ function createTrelloMember($member = array() , $admin_user_id = array() , $new_
         pg_fetch_assoc(pg_query_params($db_lnk, 'INSERT INTO boards_users (created, modified, user_id, board_id, board_user_role_id) VALUES (now(), now(), $1, $2, $3) RETURNING id', $qry_val_arr));
     }
     $is_board_subscribers_exist = executeQuery('SELECT * FROM board_subscribers WHERE user_id = $1 and board_id = $2', $query_val);
-    $auto_subscribe_on_board = (AUTO_SUBSCRIBE_ON_BOARD === 'Enabled') ? 'true' : 'false';
+    $auto_subscribe_on_board = (AUTO_SUBSCRIBE_ON_BOARD === 'Enabled') ? 'true' : false;
     if ($auto_subscribe_on_board && !$is_board_subscribers_exist) {
         $qry_val_arr = array(
             $user_id,
@@ -1609,7 +1609,7 @@ function importWekanBoard($board = array())
                             $board_user_role_id
                         );
                         pg_fetch_assoc(pg_query_params($db_lnk, 'INSERT INTO boards_users (created, modified, user_id, board_id, board_user_role_id) VALUES (now(), now(), $1, $2, $3) RETURNING id', $qry_val_arr));
-                        $auto_subscribe_on_board = (AUTO_SUBSCRIBE_ON_BOARD === 'Enabled') ? 'true' : 'false';
+                        $auto_subscribe_on_board = (AUTO_SUBSCRIBE_ON_BOARD === 'Enabled') ? 'true' : false;
                         if ($auto_subscribe_on_board) {
                             $qry_val_arr = array(
                                 $users[$wekan_user_id],
@@ -1628,7 +1628,7 @@ function importWekanBoard($board = array())
             1
         );
         pg_fetch_assoc(pg_query_params($db_lnk, 'INSERT INTO boards_users (created, modified, user_id, board_id, board_user_role_id) VALUES (now(), now(), $1, $2, $3) RETURNING id', $qry_val_arr));
-        $auto_subscribe_on_board = (AUTO_SUBSCRIBE_ON_BOARD === 'Enabled') ? 'true' : 'false';
+        $auto_subscribe_on_board = (AUTO_SUBSCRIBE_ON_BOARD === 'Enabled') ? 'true' : false;
         if ($auto_subscribe_on_board) {
             $qry_val_arr = array(
                 $authUser['id'],


### PR DESCRIPTION
## Description
When the admin changes the options for auto subscribe to board and card, when we create the board, the auto subscribe to the board and card is set to the default value issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
