### PR TITLE
Fixes #1851 : Getting php warnings as Undefined variable: languages while loading the oauth token issue fixed

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -106,6 +106,7 @@ function r_get($r_resource_cmd, $r_resource_vars, $r_resource_filters)
                 $folder_iso2_code = $folder[count($folder) - 2];
                 array_push($lang_iso2_codes, $folder_iso2_code);
             }
+            $languages = array();
             $qry_val_arr = array(
                 '{' . implode($lang_iso2_codes, ',') . '}'
             );


### PR DESCRIPTION
## Description
Getting php warnings as Undefined variable: languages while loading the oauth token issue fixed

## Related Issue
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
