### PR TITLE
Fixes #1857 : The boards in the organization pages are not ordered based on their name issue fixed

### DIFF
--- a/client/js/views/application_view.js
+++ b/client/js/views/application_view.js
@@ -697,10 +697,10 @@ App.ApplicationView = Backbone.View.extend({
                                                     organization_starred_board.lists.add(filtered_lists);
                                                     if ($('.js-organization-starred-boards-' + organization_starred_board.attributes.organization_id).length === 0) {
                                                         var starred_board_organization_name = filterXSS(organization_starred_board.attributes.organization_name);
-                                                        $('.js-header-starred-boards').parent().append('<div class="col-xs-12 js-organization-starred-boards-' + organization_starred_board.attributes.organization_id + '"><h4>' + i18next.t('%s', {
+                                                        $('.js-header-starred-boards').parent().append('<div class="col-xs-12 js-organization-starred-boards-' + organization_starred_board.attributes.organization_id + '"><h4><a href="#/organization/' + organization_starred_board.attributes.organization_id + '" class="cur">' + i18next.t('%s', {
                                                             postProcess: 'sprintf',
                                                             sprintf: [starred_board_organization_name]
-                                                        }) + '</h4></div>');
+                                                        }) + '</a></h4></div>');
                                                     }
                                                     $('.js-organization-starred-boards-' + organization_starred_board.attributes.organization_id).append(new App.BoardSimpleView({
                                                         model: organization_starred_board,
@@ -794,10 +794,10 @@ App.ApplicationView = Backbone.View.extend({
                                                 if ($('.js-organization-' + closed_organization_board.attributes.organization_id).length === 0) {
                                                     if ($('.js-organization-closed-boards-' + closed_organization_board.attributes.organization_id).length === 0) {
                                                         var closed_board_organization_name = filterXSS(closed_organization_board.attributes.organization_name);
-                                                        $('.js-header-closed-boards').parent().append('<div class="col-xs-12 js-organization-closed-boards-' + closed_organization_board.attributes.organization_id + '"><h4>' + i18next.t('%s', {
+                                                        $('.js-header-closed-boards').parent().append('<div class="col-xs-12 js-organization-closed-boards-' + closed_organization_board.attributes.organization_id + '"><h4><a href="#/organization/' + closed_organization_board.attributes.organization_id + '" class="cur">' + i18next.t('%s', {
                                                             postProcess: 'sprintf',
                                                             sprintf: [closed_board_organization_name]
-                                                        }) + '</h4></div>');
+                                                        }) + '</a></h4></div>');
                                                     }
                                                 }
                                                 closed_organization_board.board_subscribers.add(closed_organization_board.attributes.boards_subscribers);
@@ -868,10 +868,10 @@ App.ApplicationView = Backbone.View.extend({
                                             _.each(organization_boards, function(board) {
                                                 if ($('.js-organization-' + board.attributes.organization_id).length === 0) {
                                                     var organization_name = filterXSS(board.attributes.organization_name);
-                                                    $('.js-my-boards').parent().append('<div class="col-xs-12 js-organization_boards js-organization-' + board.attributes.organization_id + '" data-organization_id ="' + board.attributes.organization_id + '" ><h4>' + i18next.t('%s', {
+                                                    $('.js-my-boards').parent().append('<div class="col-xs-12 js-organization_boards js-organization-' + board.attributes.organization_id + '" data-organization_id ="' + board.attributes.organization_id + '" ><h4><a href="#/organization/' + board.attributes.organization_id + '" class="cur">' + i18next.t('%s', {
                                                         postProcess: 'sprintf',
                                                         sprintf: [organization_name]
-                                                    }) + '</h4></div>');
+                                                    }) + '</a></h4></div>');
                                                 }
                                                 var board_filter = _.matches({
                                                     is_archived: 0

--- a/client/js/views/organization_view.js
+++ b/client/js/views/organization_view.js
@@ -191,6 +191,8 @@ App.OrganizationsView = Backbone.View.extend({
             model: this.model,
             type: self.page_view_type
         }).el);
+        this.model.boards.setSortField('name', 'asc');
+        this.model.boards.sort();
         this.$el.html(this.template({
             organization: this.model,
             type: this.type


### PR DESCRIPTION
## Description
The boards in the organization pages are not ordered based on their name issue fixed and the organization names on the boards page will redirect to the particular organization page

## Related Issue 
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
