### PR TITLE
Fixes #1870 : When the admin disabled the "edit user details" role for normal users, there is an error producing while updating from last activity for users issue fixed

### DIFF
--- a/server/php/libs/core.php
+++ b/server/php/libs/core.php
@@ -529,6 +529,9 @@ function checkAclLinks($r_request_method = 'GET', $r_resource_cmd = '/users', $r
         if (!empty($r_request_method) && ($r_request_method === 'GET') && !empty($r_resource_cmd) && ($r_resource_cmd === '/users/?/activities')) {
             return true;
         }
+        if (!empty($r_request_method) && ($r_request_method === 'PUT') && !empty($r_resource_cmd) && $r_resource_cmd === '/users/?' && !empty($post_data['last_activity_id'])) {
+            return true;        
+        }
         $qry_val_arr = array(
             $role,
             $r_request_method,


### PR DESCRIPTION
## Description
When the admin disabled the "edit user details" role for normal users, there is an error producing while updating from last activity for users issue fixed

## Related Issue
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
