### PR TITLE
Fixes #1874 : While installing restyaboard using shell script, failed to add respository for installing php issue fixed

### DIFF
--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -304,7 +304,7 @@
 				
 				apt-get update -y
 				apt-get upgrade -y
-				apt-get install python-software-properties -y
+				apt-get install python-software-properties software-properties-common -y
 				add-apt-repository ppa:ondrej/php
 				apt-get update -y
 				apt-get install libjpeg8 -y --allow-unauthenticated


### PR DESCRIPTION
## Description
While installing restyaboard using shell script, failed to add respository for installing php issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
