### PR TITLE
Fixes #1881 : When the admin didn't give view_board permission to the  guest role, while loading card link, it doesn't show `Board not found` warning issue fixed

### DIFF
--- a/client/js/views/application_view.js
+++ b/client/js/views/application_view.js
@@ -519,6 +519,8 @@ App.ApplicationView = Backbone.View.extend({
                     slug: 'view_board'
                 }))) {
                 page.board_view();
+            } else {
+                page.board_view();
             }
         } else if (page.model == 'organizations_view') {
             changeTitle(i18next.t('Organization'));


### PR DESCRIPTION
## Description
When the admin didn't give view_board permission to the  guest role, while loading card link, it doesn't show `Board not found` warning issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
