### PR TITLE
Fixes #1883 : Board Name of board templates in the board listing of 'Add Board' option is not aligned correctly issue fixed

### DIFF
--- a/client/js/libs/select2.js
+++ b/client/js/libs/select2.js
@@ -953,7 +953,7 @@ the specific language governing permissions and limitations under the Apache Lic
                             label.attr("role", "option");
 
                             formatted=opts.formatResult(result, label, query, self.opts.escapeMarkup);
-                            formatted = filterXSS(formatted);
+                            formatted = formatted;
                             if (formatted!==undefined) {
                                 label.html(formatted);
                                 node.append(label);


### PR DESCRIPTION
## Description
Board Name of board templates in the board listing of 'Add Board' option is not aligned correctly issue fixed

## Related Issue 
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
