### PR TITLE
Fixes #1889 : Gantt View takes more time to add 'start date' option in list sort options issue fixed

### DIFF
--- a/client/js/templates/list.jst.ejs
+++ b/client/js/templates/list.jst.ejs
@@ -42,6 +42,7 @@
 				 </li>
 				 <li class=" js-createdDate js-sort-by-<%- list.attributes.id %>"><a title="<%- i18next.t('Created Date') %>" href="#" class="js-sort-by" data-sort-by="created_date"><%- i18next.t('Created Date') %></a></li>
 				 <li class=" js-listMovedDate js-sort-by-<%- list.attributes.id %>"><a title="<%- i18next.t('List Moved Date') %>" href="#" class="js-sort-by" data-sort-by="list_moved_date"><%- i18next.t('List Moved Date') %></a></li>
+				 <li class=" js-startDate js-sort-by-<%- list.attributes.id %> hide"><a title="<%- i18next.t('Start Date') %>" href="#" class="js-sort-by" data-sort-by="start_date"><%- i18next.t('Start Date') %></a></li>
 			 </ul>
 			</div>
 		</div>


### PR DESCRIPTION
## Description
Gantt View takes more time to add 'start date' option in list sort options issue fixed

## Related Issue
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
