### PR TITLE
Fixes #1891 : During filter cards on board page, after reloading the board page with filter, rarely board page not displayed issue fixed

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -1850,6 +1850,8 @@ App.BoardHeaderView = Backbone.View.extend({
             filter = 'list';
         } else if (current_url.length === 3 && current_url[2] == 'gantt') {
             filter = 'gantt';
+        } else if (current_url.length === 3 && current_url[1] == 'board') {
+            current_param[0] = current_url[1] + '/' + current_url[2];
         }
         var filter_query = '';
         $('li.selected > div.js-label', $('ul.js-board-labels')).each(function() {


### PR DESCRIPTION
## Description
During filter cards on board page, after reloading the board page with filter, rarely board page not displayed issue fixed

## Related Issue
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
