### PR TITLE
Fixes #1896 : While filtering cards in board page with non-special characters as label name, the page is getting redirected to board page issue fixed

### DIFF
--- a/client/js/libs/backbone.js
+++ b/client/js/libs/backbone.js
@@ -1358,12 +1358,19 @@
     atRoot: function() {
       return this.location.pathname.replace(/[^\/]$/, '$&/') === this.root;
     },
+    
+    // Unicode characters in `location.pathname` are percent encoded so they're
+    // decoded for comparison. `%25` should not be decoded since it may be part
+    // of an encoded parameter.
+    decodeFragment: function(fragment) {
+      return decodeURI(fragment.replace(/%25/g, '%2525'));
+    },
 
     // Gets the true hash value. Cannot use location.hash directly due to bug
     // in Firefox where location.hash will always be decoded.
     getHash: function(window) {
       var match = (window || this).location.href.match(/#(.*)$/);
-      return match ? match[1] : '';
+      return match ? this.decodeFragment(match[1]) : ''; 
     },
 
     // Get the cross-browser normalized URL fragment, either from the URL,


### PR DESCRIPTION
## Description
While filtering cards in board page with non-special characters as label name, the page is getting redirected to board page issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
