### PR TITLE
Fixes #1929 : In particular public organization page, the long board name truncate not working without login issue fixed

### DIFF
--- a/client/js/templates/organization_board.jst.ejs
+++ b/client/js/templates/organization_board.jst.ejs
@@ -3,7 +3,7 @@
 	<div class="panel-body bg-warning">
 		<div class="clearfix">
 			<h4 class="col-sm-7 col-xs-5 navbar-btn">
-				<span class="show row navbar-btn">
+				<span class="htruncate show row navbar-btn">
 				<% if(!_.isEmpty(role_links.where({slug: "starred_board"}))){ %>
 					<a class="htruncate btn-block" href="#/board/<%- board.id %>" title="<%- board.attributes.name %>"><%- board.attributes.name%></a>
 				<% } else { %>


### PR DESCRIPTION
## Description
In particular public organization page, the long board name truncate not working without login issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
