### PR TITLE
Fixes #1936 : From e-mail contains root@ before the email address setup which then fails when tries to send the email issue fixed

### DIFF
--- a/server/php/libs/core.php
+++ b/server/php/libs/core.php
@@ -602,7 +602,7 @@ function sendMail($template, $replace_content, $to, $reply_to_mail = '')
         $headers.= "Content-Type: text/html; charset=UTF-8" . PHP_EOL;
         $headers.= "X-Mailer: Restyaboard (0.6.5; +http://restya.com/board)" . PHP_EOL;
         $headers.= "X-Auto-Response-Suppress: All" . PHP_EOL;
-        $result = mail($to, $subject, $message, $headers);
+        $result = mail($to, $subject, $message, $headers, '-f' . DEFAULT_FROM_EMAIL_ADDRESS);
         if (R_DEBUG) {
             if (!$result) {
                 $compose_string = 'F, ' . $from_email . ', ' . $to . ', ' . $subject;


### PR DESCRIPTION
## Description
From e-mail contains root@ before the email address setup which then fails when tries to send the email issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
