### PR TITLE
Fixes #1960 : When closing modal card, if there is unsaved changes, it is now show the warning content about the unsaved changes issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -705,7 +705,7 @@ App.ModalCardView = Backbone.View.extend({
      */
     cancelCardDescEditForm: function(e) {
         this.$el.find('.js-show-card-desc').next().show();
-        this.$el.find('#cardDescriptionEditForm').hide();
+        this.$el.find('#cardDescriptionEditForm').addClass('hide');
         return false;
     },
     showMemberSearchKeyDown: function(e) {
@@ -1261,8 +1261,13 @@ App.ModalCardView = Backbone.View.extend({
                     self.$el.find('.js-modal-settings').removeClass('hide');
                 },
                 beforeClose: function(event, dialog) {
+                    var description;
                     var comment = $('#js-card-modal-' + self.model.id).find('#inputAddComment').val();
-                    var description = $('#js-card-modal-' + self.model.id).find('#inputCarddescriptions').val();
+                    if ($('#js-card-modal-' + self.model.id).find('#cardDescriptionEditForm').hasClass('hide')) {
+                        description = '';
+                    } else {
+                        description = $('#js-card-modal-' + self.model.id).find('#inputCarddescriptions').val();
+                    }
                     if (!_.isEmpty(comment) || !_.isEmpty(description)) {
                         if (window.confirm(i18next.t('You have unsaved changes on this card. Do you want to close this card and discard your changes or stay on this card?'))) {
                             is_modalCard_close = true;


### PR DESCRIPTION
## Description
When closing modal card, if there is unsaved changes, it is now show the warning content about the unsaved changes issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
