### PR TITLE
Fixes #1975 : When the user moves the card within it's original list,the other users didn't get updated about the card position change in the live version issue fixed

### DIFF
--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -1246,6 +1246,8 @@ App.FooterView = Backbone.View.extend({
                                                     k++;
                                                 });
                                             }
+                                        } else if (activity.attributes.type === 'change_card_position') {
+                                            card.set('position', activity.attributes.card_position);
                                         } else if (activity.attributes.type === 'delete_card_attachment') {
                                             self.board.attachments.remove(self.board.attachments.findWhere({
                                                 id: parseInt(activity.attributes.foreign_id)


### PR DESCRIPTION
## Description
- When the user moves the card within it's original list,the other users didn't get updated about the card position change in the live version issue fixed

## Related Issue
 No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
