### PR TITLE
Fixes #2040 : Thumbnail preview breaks in Windows when filename has UTF-8 characters issue fixed

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -4362,11 +4362,11 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                     if (!file_exists($mediadir)) {
                         mkdir($mediadir, 0777, true);
                     }
-                    $file_arr = pathinfo($file['name'][$i]);
                     $cur_os = strtolower(PHP_OS);
                     if (substr($cur_os, 0, 3) === 'win') {
                         $file['name'][$i] = urlencode($file['name'][$i]);
                     }
+                    $file_arr = pathinfo($file['name'][$i]);
                     $filename_without_ext = $file_arr['filename'];
                     if (file_exists($mediadir . DIRECTORY_SEPARATOR . $file['name'][$i])) {
                         $filename_without_ext = $file_arr['filename'] . '-' . mt_rand(0, 999);

--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -3900,6 +3900,10 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                                     if (!file_exists($mediadir)) {
                                         mkdir($mediadir, 0777, true);
                                     }
+                                    $cur_os = strtolower(PHP_OS);
+                                    if (substr($cur_os, 0, 3) === 'win') {
+                                        $file['name'][$i] = urlencode($file['name'][$i]);
+                                    }
                                     $file_arr = pathinfo($file['name'][$i]);
                                     $filename_without_ext = $file_arr['filename'];
                                     if (file_exists($mediadir . DIRECTORY_SEPARATOR . $file['name'][$i])) {
@@ -4290,6 +4294,10 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                 mkdir($mediadir, 0777, true);
             }
             $file = $_FILES['attachment'];
+            $cur_os = strtolower(PHP_OS);
+            if (substr($cur_os, 0, 3) === 'win') {
+                $file['name'] = urlencode($file['name']);
+            }
             $file_arr = pathinfo($file['name']);
             $filename_without_ext = $file_arr['filename'];
             if (file_exists($mediadir . DIRECTORY_SEPARATOR . $file['name'])) {
@@ -4355,6 +4363,10 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                         mkdir($mediadir, 0777, true);
                     }
                     $file_arr = pathinfo($file['name'][$i]);
+                    $cur_os = strtolower(PHP_OS);
+                    if (substr($cur_os, 0, 3) === 'win') {
+                        $file['name'][$i] = urlencode($file['name'][$i]);
+                    }
                     $filename_without_ext = $file_arr['filename'];
                     if (file_exists($mediadir . DIRECTORY_SEPARATOR . $file['name'][$i])) {
                         $filename_without_ext = $file_arr['filename'] . '-' . mt_rand(0, 999);


### PR DESCRIPTION
## Description
Thumbnail preview breaks in Windows when filename has UTF-8 characters issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
