### PR TITLE
Fixes #2040 : Thumbnail preview breaks in Windows when filename has UTF-8 characters issue fixed

### DIFF
--- a/client/js/templates/attachment.jst.ejs
+++ b/client/js/templates/attachment.jst.ejs
@@ -4,20 +4,20 @@
 			var picture_path = attachment.showImage('CardAttachment', attachment.attributes.id, 'original' );
 			var picture_thumb = attachment.showImage('CardAttachment', attachment.attributes.id, 'large_thumb' );
 		%>
-		<a data-fancybox="images" data-caption="<%= attachment.attributes.name %>" href="<%= picture_path %>" class="pull-left navbar-btn img-thumbnail thumb-img js-attachment-<%- id %>">
+		<a data-fancybox="images" data-caption="<%= decodeURI(attachment.attributes.name) %>" href="<%= picture_path %>" class="pull-left navbar-btn img-thumbnail thumb-img js-attachment-<%- id %>">
 			<img src="<%= picture_thumb %>">
 		</a>
 			
 		<% } else if (attachment.attributes.name.toLowerCase().match(/\.(pdf)$/) && !_.isUndefined(attachment.attributes.doc_image_path) && !_.isEmpty(attachment.attributes.doc_image_path) && attachment.attributes.doc_image_path !== null) { 
 			var document_path = attachment.documentLink('Card', attachment.attributes); %>
-			<a data-fancybox="images" data-caption="<%= attachment.attributes.name %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- id %>">
+			<a data-fancybox="images" data-caption="<%= decodeURI(attachment.attributes.name) %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- id %>">
 				<img src="<%= attachment.attributes.doc_image_path %>">
 			</a>
 		<% } else {
 			var document_path = attachment.documentLink('Card', attachment.attributes);
 			var extension = attachment.attributes.name.split('.');
 		%>
-			<a data-fancybox="images" data-caption="<%= attachment.attributes.name %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail thumb-img js-attachment-<%- id %>"><p class="thumb-img"><%- extension[extension.length - 1].toUpperCase() %></p></a>
+			<a data-fancybox="images" data-caption="<%= decodeURI(attachment.attributes.name) %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail thumb-img js-attachment-<%- id %>"><p class="thumb-img"><%- extension[extension.length - 1].toUpperCase() %></p></a>
 		<% } %>
 	<% } else if(!_.isEmpty(attachment.attributes.link)){ %>
 	<%   
@@ -44,11 +44,11 @@
 		<%   
 			if (navigator.userAgent.toLowerCase().indexOf('uiwebview') > -1) {
 		%>
-			<a target="_self" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- attachment.attributes.name %>">
+			<a target="_self" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- decodeURI(attachment.attributes.name) %>">
 		<% } else { %>
-			<a target="_blank" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- attachment.attributes.name %>">
+			<a target="_blank" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- decodeURI(attachment.attributes.name) %>">
 		<% } %>
-			<span class="htruncate col-xs-12 btn-block"><%- attachment.attributes.name %></span><span class="show btn-block col-xs-12"><%- i18next.t('Added') %> <small class="text-muted">
+			<span class="htruncate col-xs-12 btn-block"><%- decodeURI(attachment.attributes.name) %></span><span class="show btn-block col-xs-12"><%- i18next.t('Added') %> <small class="text-muted">
 			<% var created = parse_date(attachment.attributes.created, authuser, 'js-timeago-attachment1-'+attachment.attributes.id); %>
 			<span class="js-timeago-attachment1-<%- attachment.attributes.id %>"></span>
 			</small></span></a>

--- a/client/js/templates/card_attachment.jst.ejs
+++ b/client/js/templates/card_attachment.jst.ejs
@@ -3,19 +3,19 @@
 		var picture_path = attachment.showImage('CardAttachment', attachment.attributes.id, 'original' );
 		var picture_thumb = attachment.showImage('CardAttachment', attachment.attributes.id, 'large_thumb' );
 	%>
-	<a data-fancybox="images" data-caption="<%= attachment.attributes.name %>" href="<%= picture_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- card_id %>">
+	<a data-fancybox="images" data-caption="<%= decodeURI(attachment.attributes.name) %>" href="<%= picture_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- card_id %>">
 		<img src="<%= picture_thumb %>">
 	</a>
 	<% } else if (attachment.attributes.name.toLowerCase().match(/\.(pdf)$/) && !_.isUndefined(attachment.attributes.doc_image_path) && !_.isEmpty(attachment.attributes.doc_image_path) && attachment.attributes.doc_image_path !== null) { 
 		var document_path = attachment.documentLink('Card', attachment.attributes); %>
-		<a data-fancybox="images" data-caption="<%= attachment.attributes.name %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- card_id %>">
+		<a data-fancybox="images" data-caption="<%= decodeURI(attachment.attributes.name) %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- card_id %>">
 			<img src="<%= attachment.attributes.doc_image_path %>">
 		</a>
 	<% } else {
 		var document_path = attachment.documentLink('Card', attachment.attributes);
 		var extension = attachment.attributes.name.split('.');
 	%>
-		<a data-fancybox="images" data-caption="<%= attachment.attributes.name %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- card_id %>"><p class="thumb-img"><%- extension[extension.length - 1].toUpperCase() %></p></a>
+		<a data-fancybox="images" data-caption="<%= decodeURI(attachment.attributes.name) %>" href="<%= document_path %>" class="pull-left navbar-btn img-thumbnail js-card-attachment-<%- card_id %>"><p class="thumb-img"><%- extension[extension.length - 1].toUpperCase() %></p></a>
 	<% } %>
 <% } else if(!_.isEmpty(attachment.attributes.link)){ %>
 	<%   
@@ -41,9 +41,9 @@
 	<% 
 		if (navigator.userAgent.toLowerCase().indexOf('uiwebview') > -1) { 
 	%>
-		<a target="_self" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- attachment.attributes.name %>"><span class="show htruncate col-xs-11 nav"><%- attachment.attributes.name %></span>
+		<a target="_self" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- decodeURI(attachment.attributes.name) %>"><span class="show htruncate col-xs-11 nav"><%- decodeURI(attachment.attributes.name) %></span>
 	<% } else { %>
-		<a target="_blank" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- attachment.attributes.name %>"><span class="show htruncate col-xs-11 nav"><%- attachment.attributes.name %></span>
+		<a target="_blank" href="<%= attachment.downloadLink('download', attachment.attributes.id) %>" title="<%- decodeURI(attachment.attributes.name) %>"><span class="show htruncate col-xs-11 nav"><%- decodeURI(attachment.attributes.name) %></span>
 	<% } %>
 		<span class="show btn-block col-xs-12"><%- i18next.t('Added') %> <small class="text-muted">
 		<% var created = parse_date(attachment.attributes.created, authuser, 'js-timeago-card-attachment1-'+attachment.attributes.id); %>


### PR DESCRIPTION
## Description
Thumbnail preview breaks in Windows when filename has UTF-8 characters issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
