### PR TITLE
Fixes #2072 : Unable to delete card description after adding card description once in the modal card view page issue fixed

### DIFF
--- a/client/js/templates/modal_card_view.jst.ejs
+++ b/client/js/templates/modal_card_view.jst.ejs
@@ -204,7 +204,7 @@
 						</ul>
 						<div class="well-sm"></div>
 						<div class="form-group required">
-						  <textarea rows="4" data-edit_mode='2' id="inputCarddescriptions" name="description" class="form-control js-card-input" required><%- card.attributes.description %></textarea>
+						  <textarea rows="4" data-edit_mode='2' id="inputCarddescriptions" name="description" class="form-control js-card-input"><%- card.attributes.description %></textarea>
 							<div class="panel js-card-desc-edit-panel hide no-mar">
 								<div class="panel-body js-card-desc-edit-preview github-markdown"></div>
 							</div>

--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -828,11 +828,6 @@ App.ModalCardView = Backbone.View.extend({
             $('<div class="error-msg-name text-primary h6">' + i18next.t('Whitespace is not allowed') + '</div>').insertAfter('#inputCardName');
             return false;
         }
-        if (edit_mode === 2 && $.trim(data.description) === '') {
-            $('.error-msg-name').remove();
-            $('<div class="error-msg-name text-primary h6">' + i18next.t('Whitespace is not allowed') + '</div>').insertAfter('#inputCarddescriptions');
-            return false;
-        }
         if (!_.isUndefined(data.due_date) || !_.isUndefined(data.due_time)) {
             data = {
                 to_date: data.due_date,
@@ -853,7 +848,7 @@ App.ModalCardView = Backbone.View.extend({
         if (!_.isUndefined(data.name)) {
             target.prev('h4').html(_.escape(data.name)).removeClass('hide');
         }
-        if (!_.isUndefined(data.description)) {
+        if (!_.isUndefined(data.description) && !_.isEmpty(data.description)) {
             if (!$.trim($('#inputCarddescriptions').val()).length) {
                 $('.error-msg').remove();
                 $('<div class="error-msg text-primary h6">Whitespace is not allowed</div>').insertAfter('#inputCarddescriptions');


### PR DESCRIPTION
## Description
Unable to delete card description after adding card description once in the modal card view page issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
