### PR TITLE
Fixes #2078 : In some client server, while the site_url_for_shell file written in tmp folder, it's not working issue fixed

### DIFF
--- a/server/php/config.inc.php
+++ b/server/php/config.inc.php
@@ -25,8 +25,8 @@ if (!defined('JSON_UNESCAPED_UNICODE')) {
     define('JSON_UNESCAPED_UNICODE', 256);
 }
 define('APP_PATH', dirname(dirname(dirname(__FILE__))));
-define('SITE_URL_FOR_SHELL', sys_get_temp_dir() . '/restya_site_url_for_shell.php');
-define('CLIENT_INFORMATION', sys_get_temp_dir() . '/restya_client_information.php');
+define('SITE_URL_FOR_SHELL', APP_PATH . '/tmp/cache/site_url_for_shell.php');
+define('CLIENT_INFORMATION', APP_PATH . '/tmp/cache/client_information.php');
 
 // While changing below oAuth credentials, have to update in oauth_clients table also.
 if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {


### PR DESCRIPTION
## Description
In some client server, while the site_url_for_shell file written in tmp folder, it's not working issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
