### PR TITLE
Fixes #2161: Links in the Admin panel headers should be arranged in order and the admin panel header breaks design on some pages issue fixed

### DIFF
--- a/client/js/templates/header.jst.ejs
+++ b/client/js/templates/header.jst.ejs
@@ -237,14 +237,14 @@
 									<%- i18next.t("User Logins") %>
 								</a>
 							</li>
-							<li class="js-admin-board-menu navbar-btn">
-								<a title="<%- i18next.t('Boards') %>" href="#/boards/list">
-									<%- i18next.t("Boards") %>
-								</a>
-							</li>
 							<li class="js-admin-role-menu navbar-btn">
 								<a title="<%- i18next.t('Roles') %>" href="#/roles">
 									<%- i18next.t("Roles") %>
+								</a>
+							</li>
+							<li class="js-admin-board-menu navbar-btn">
+								<a title="<%- i18next.t('Boards') %>" href="#/boards/list">
+									<%- i18next.t("Boards") %>
 								</a>
 							</li>
 							<li class="js-admin-app-menu navbar-btn">


### PR DESCRIPTION
## Description
Links in the Admin panel headers should be arranged in order and the admin panel header breaks design on some pages issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
