### PR TITLE
Fixes #2180: The organization members are not added to the board created by clicking the create new board option in that organization block of boards page issue fixed

### DIFF
--- a/client/js/views/board_simple_view.js
+++ b/client/js/views/board_simple_view.js
@@ -122,6 +122,7 @@ App.BoardSimpleView = Backbone.View.extend({
                 data.page_mode = 1;
                 if (organization_id) {
                     data.organization_id = organization_id;
+                    data.page_mode = 2;
                 }
                 $('.js-show-boards-list-simple-response', parent).html(new App.BoardAddView({
                     model: data


### PR DESCRIPTION
## Description
The created board in the organization block of the boards page will contain the organization members as the board member

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
