### PR TITLE
Fixes #2252: Strong warning content is shown while removing owner role user from board or organization issue fixed

### DIFF
--- a/client/js/templates/board_user_remove_confirm.jst.ejs
+++ b/client/js/templates/board_user_remove_confirm.jst.ejs
@@ -13,8 +13,11 @@
 			<ul class="dropdown-menu dropdown-list show">
 				<li>
 					<a class="js-delete-board-member" data-board_user_id="<%- board_user.attributes.id %>" href="#">
-					 
-					 <%- i18next.t('Remove %s from %s Boards? The member will be removed from all cards on this board.', { postProcess: 'sprintf', sprintf: [board_user.attributes.username,board_user.attributes.board_name]}) %>
+					<% if(parseInt(board_user.attributes.board_user_role_id) == 1) { %> 
+					 <%- i18next.t('Remove %s from %s Boards? Please be sure that there is another user who is an owner of this board. The member will be removed from all cards on this board.', { postProcess: 'sprintf', sprintf: [board_user.attributes.username,board_user.attributes.board_name]}) %>
+					<% } else { %>
+						<%- i18next.t('Remove %s from %s Boards? The member will be removed from all cards on this board.', { postProcess: 'sprintf', sprintf: [board_user.attributes.username,board_user.attributes.board_name]}) %>
+					<% } %>
 				 </li>
 			</ul>
 		</form>

--- a/client/js/templates/organization_member_remove_form.jst.ejs
+++ b/client/js/templates/organization_member_remove_form.jst.ejs
@@ -1,6 +1,12 @@
 <li class="col-xs-12">
 	<a class="show row small well-xs js-delete-organization-member" data-organizations_user_id="<%- organization_users.organizations_user_id %>" href="#">
 		<span class="show text-primary navbar-btn h5"><%- i18next.t('Remove from organization') %></span>
-		<span class="navbar-btn"><%- i18next.t('Remove all access to the organization.  The member will remain on all their boards in this organization.') %></span>
+		<span class="navbar-btn">
+			<% if (parseInt(organization_users.organizations_user_roleid) === 1) { %>
+				<%- i18next.t('Remove all access to the organization. Please be sure that there is another user who is an owner of this organization. The member will remain on all their boards in this organization.') %>
+			<% } else { %>
+				<%- i18next.t('Remove all access to the organization.  The member will remain on all their boards in this organization.') %>
+			<% } %>
+		</span>
 	</a>
 </li>

--- a/client/js/templates/organizations_user_view.jst.ejs
+++ b/client/js/templates/organizations_user_view.jst.ejs
@@ -112,8 +112,8 @@
 										<% if(organizations_users.length !== 1) { %>
 											<li class="dropdown navbar-btn text-left js-show-confirm-delete-organization-member-dropdown">
 												<% 
-												if(!_.isUndefined(authuser.user) && (authuser.user.role_id == 1 || !_.isEmpty(organization.acl_links.where({slug: "remove_organization_user",organization_user_role_id: parseInt(organization.organization_user_role_id)})))){%>
-														<a class="btn btn-primary dropdown-toggle js-show-confirm-delete-organization-member" data-organizations_user_id="<%- organizations_user.attributes.id %>" data-toggle="dropdown" href="#"><span><i class="icon-remove"></i></span>
+												if(!_.isUndefined(authuser.user) && (authuser.user.role_id == 1 || !_.isEmpty(organization.acl_links.where({slug: "remove_organization_user",organization_user_role_id: parseInt(organization.organization_user_role_id)})))){ %>
+														<a class="btn btn-primary dropdown-toggle js-show-confirm-delete-organization-member" data-organizations_user_id="<%- organizations_user.attributes.id %>" data-organizations_user_roleid="<%- organizations_user.attributes.organization_user_role_id %>" data-toggle="dropdown" href="#"><span><i class="icon-remove"></i></span>
 														<span>
 														<% if(!_.isUndefined(authuser.user) && organizations_user.attributes.user_id == authuser.user.id) { %>
 															<%- i18next.t('Leave') %>

--- a/client/js/views/organization_view.js
+++ b/client/js/views/organization_view.js
@@ -123,7 +123,9 @@ App.OrganizationsView = Backbone.View.extend({
         var insert = $('.js-show-confirm-delete-organization-member-response', parent);
         insert.nextAll().remove();
         var organizations_user_id = target.data('organizations_user_id');
+        var organizations_user_roleid = target.data('organizations_user_roleid');
         this.model.organizations_user_id = organizations_user_id;
+        this.model.organizations_user_roleid = organizations_user_roleid;
         $(new App.OrganizationMemberRemoveFormView({
             model: this.model
         }).el).insertAfter(insert);


### PR DESCRIPTION
## Description
Strong warning content is shown while removing owner role user from board or organization issue fixed

## Related Issue
No

## Screenshots (if appropriate):
#### Board owner role removal warning message
![board_owner_removal](https://user-images.githubusercontent.com/17172525/49728140-fd9d3600-fc97-11e8-8d13-677da97fb4da.png)

#### Organization owner role removal warning message
![org_owner_role_removal](https://user-images.githubusercontent.com/17172525/49728374-916f0200-fc98-11e8-8a8b-197cdad5c9e2.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
