### PR TITLE
Fixes #2193: Mobile view no way to go back to boards issue fixed

### DIFF
--- a/client/js/templates/footer.jst.ejs
+++ b/client/js/templates/footer.jst.ejs
@@ -8,13 +8,13 @@ if (_.isEmpty(role_links.where({
 	}
 }
 %>
-	<section id="cookie_information" class="hide">
+	<section id="cookie_information" class="hide hidden-xs">
 		<div class="row navbar navbar-default list-group-item-text"></div>
 	</section>
-	<section id="broadcast_information" class="hide">
+	<section id="broadcast_information" class="hide hidden-xs">
 		<div class="row navbar navbar-default list-group-item-text"></div>
 	</section>
-	<section id="broadcast_hide_arrow" class="hide">
+	<section id="broadcast_hide_arrow" class="hide hidden-xs">
 		<a href="#" class="broadcast-content-show js-broadcast-show pull-right" title="show">
 			<i class="icon-angle-up"></i>
 			</i>


### PR DESCRIPTION
## Description
Mobile view no way to go back to boards issue fixed

## Related Issue
No

## Screenshots (if appropriate):
![boards_icon_in_board_page](https://user-images.githubusercontent.com/17172525/50092450-268f6f00-0234-11e9-82f2-8194b62313c6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
