### PR TITLE
Fixes #2260: The warning for the wrong user credentials are not shown in the login page issue fixede

### DIFF
--- a/client/js/views/login_view.js
+++ b/client/js/views/login_view.js
@@ -76,7 +76,7 @@ App.LoginView = Backbone.View.extend({
                         self.flash('danger', i18next.t('Sorry, login failed. Internet connection not available.'));
                     } else if (response.code === 'LDAP' && response.error === 'ERROR_LDAP_USER_LIMIT_EXCEED') {
                         self.flash('danger', i18next.t('Sorry, LDAP users limit exceed.'));
-                    } else if (response.code === 'email' || (response.code === 'LDAP' && response.error === 'ERROR_LDAP_SERVER_CONNECT_FAILED')) {
+                    } else if (response.code === 'email' || (response.code === 'LDAP' && (response.error === 'ERROR_LDAP_SERVER_CONNECT_FAILED' || response.error === 'ERROR_LDAP_EMAIL_NOT_ASSOCIATED'))) {
                         $('input#inputPassword', target).val('');
                         self.flash('danger', i18next.t('Sorry, login failed. Either your username or password are incorrect or admin deactivated your account.'));
                     } else {


### PR DESCRIPTION
## Description
The warning for the wrong user credentials are not shown in the login page issue fixede

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
