### PR TITLE
Fixes #2270: Rarely the responseTypes from the OAuth2 is empty issue fixed

### DIFF
--- a/server/php/libs/vendors/OAuth2/Server.php
+++ b/server/php/libs/vendors/OAuth2/Server.php
@@ -452,6 +452,9 @@ class Server implements ResourceControllerInterface,
         if (!isset($this->storages['client'])) {
             throw new \LogicException("You must supply a storage object implementing OAuth2\Storage\ClientInterface to use the authorize server");
         }
+        if (!isset($this->responseTypes)) {
+            $this->responseTypes = array();
+        }
         if (0 == count($this->responseTypes)) {
             $this->responseTypes = $this->getDefaultResponseTypes();
         }


### PR DESCRIPTION
## Description
Rarely the responseTypes from the OAuth2 is an empty issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
