### PR TITLE
Fixes #2206: The user profile image thumbnail size changed to 64*64

### DIFF
--- a/client/js/templates/user_view.jst.ejs
+++ b/client/js/templates/user_view.jst.ejs
@@ -115,7 +115,7 @@
 												var profile_picture_path = user.showImage('User', user.attributes.id, 'normal_thumb' ) +'?'+ new Date().getTime();
 											%>
 												<span class="js-remove-image  profile-block show"><i class="icon icon-remove close-block cur h6"></i></span>
-												<img src="<%- profile_picture_path %>" width="50" height="50" class="js-user-avatar">
+												<img src="<%- profile_picture_path %>" width="64" height="64" class="js-user-avatar">
 											<% } else {%>
 												<i class="avatar avatar-color-194 avatar-md img-rounded"><%- user.attributes.initials %></i>									
 											<% } %>


### PR DESCRIPTION
## Description
The user profile image thumbnail size changed to 64*64

## Related Issue
No

## Screenshots:
![user_profile_thumbnail](https://user-images.githubusercontent.com/17172525/51425263-9c09a900-1bff-11e9-9992-307ac2936009.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
