### PR TITLE
Fixes #2197: Broken reply thread for comments in modal card page restored

### DIFF
--- a/client/css/custom.less
+++ b/client/css/custom.less
@@ -2296,7 +2296,7 @@ footer, header, .dashboard-header {
 }
 ul.card_activitiesnew{
 	li.activity-github-styles{
-		margin-left: 12px;
+		padding-left: 25px;
 		> .media{
 			display: flex;
 			overflow: visible;

--- a/client/js/collections/activity_collection.js
+++ b/client/js/collections/activity_collection.js
@@ -9,10 +9,6 @@ if (typeof App === 'undefined') {
  */
 App.ActivityCollection = Backbone.Collection.extend({
     model: App.Activity,
-    initialize: function() {
-        this.sortField = 'id';
-        this.sortDirection = 'desc';
-    },
     setSortField: function(field, direction) {
         this.sortField = field;
         this.sortDirection = direction;

--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -2304,8 +2304,6 @@ App.ModalCardView = Backbone.View.extend({
             var view_activity = this.$('#js-card-activities-' + self.model.id);
             //view_activity.html('');
             if (!_.isEmpty(this.model.activities)) {
-                this.model.activities.setSortField('id', 'desc');
-                this.model.activities.sort();
                 var i = 1;
                 this.model.activities.each(function(activity) {
                     $('#js-loader-img').removeClass('hide');


### PR DESCRIPTION
## Description
Broken reply thread for comments in modal card page restored

## Related Issue
No

## Screenshots:
![reply_thread](https://user-images.githubusercontent.com/17172525/51426016-864db100-1c0a-11e9-9a8e-370dea7f29a2.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
