### PR TITLE
Fixes #2205: While uploading the pdf attachments in the modal card page, the image thumbnail for pdf shows in pink color issue fixed

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -4086,7 +4086,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                                             'pdf'
                                         ))) {
                                             $im = new Imagick($mediadir . DIRECTORY_SEPARATOR . $file['name'][$i] . "[0]"); // 0-first page, 1-second page
-                                            $im->setImageColorspace(255); // prevent image colors from inverting
+                                            $im->setImageColorspace(Imagick::COLORSPACE_RGB); // prevent image colors from inverting
                                             $im->setimageformat('png');
                                             $im->thumbnailimage(200, 150); // width and height
                                             $target_hash = md5(SECURITYSALT . 'CardAttachment' . $cardAttachment['id'] . 'png' . 'original');
@@ -4513,7 +4513,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                             'pdf'
                         ))) {
                             $im = new Imagick($mediadir . DIRECTORY_SEPARATOR . $file['name'][$i] . "[0]"); // 0-first page, 1-second page
-                            $im->setImageColorspace(255); // prevent image colors from inverting
+                            $im->setImageColorspace(Imagick::COLORSPACE_RGB); // prevent image colors from inverting
                             $im->setimageformat('png');
                             $im->thumbnailimage(200, 150); // width and height
                             $target_hash = md5(SECURITYSALT . 'CardAttachment' . $cardAttachment['id'] . 'png' . 'original');
@@ -4632,7 +4632,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                     'pdf'
                 ))) {
                     $im = new Imagick($mediadir . DIRECTORY_SEPARATOR . $file['name'] . "[0]"); // 0-first page, 1-second page
-                    $im->setImageColorspace(255); // prevent image colors from inverting
+                    $im->setImageColorspace(Imagick::COLORSPACE_RGB); // prevent image colors from inverting
                     $im->setimageformat('png');
                     $im->thumbnailimage(200, 150); // width and height
                     $target_hash = md5(SECURITYSALT . 'CardAttachment' . $cardAttachment['id'] . 'png' . 'original');
@@ -4700,7 +4700,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                             'pdf'
                         ))) {
                             $im = new Imagick($mediadir . DIRECTORY_SEPARATOR . $file['name'][$i] . "[0]"); // 0-first page, 1-second page
-                            $im->setImageColorspace(255); // prevent image colors from inverting
+                            $im->setImageColorspace(Imagick::COLORSPACE_RGB); // prevent image colors from inverting
                             $im->setimageformat('png');
                             $im->thumbnailimage(200, 150); // width and height
                             $target_hash = md5(SECURITYSALT . 'CardAttachment' . $cardAttachment['id'] . 'png' . 'original');


### PR DESCRIPTION
## Description
While uploading the pdf attachments in the modal card page, the image thumbnail for pdf shows in pink color issue fixed

## Related Issue
No

## Screenshots:
![attachment](https://user-images.githubusercontent.com/17172525/51475449-5b00c880-1da8-11e9-9c1e-8115db288928.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
