### PR TITLE
Fixes #2200: Reverted the commented default bootstrap styles for abbr tag

### DIFF
--- a/client/css/normalize.less
+++ b/client/css/normalize.less
@@ -102,9 +102,9 @@ a:hover {
 // Address styling not present in IE 8/9, Safari 5, and Chrome.
 //
 
-/* abbr[title] {
+abbr[title] {
   border-bottom: 1px dotted;
-} */
+}
 
 //
 // Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome.

--- a/client/css/type.less
+++ b/client/css/type.less
@@ -219,7 +219,7 @@ abbr[title],
 // Add data-* attribute to help out our tooltip plugin, per https://github.com/twbs/bootstrap/issues/5257
 abbr[data-original-title] {
   cursor: help;
-  /* border-bottom: 1px dotted @abbr-border-color; */
+  border-bottom: 1px dotted @abbr-border-color;
 }
 .initialism {
   font-size: 90%;


### PR DESCRIPTION
## Description
Reverted the commented default bootstrap styles for abbr tag

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
