### PR TITLE
Fixes #2304: In the footer, the options for importing board is too large, have to display the Import board options separately issue fixed

### DIFF
--- a/client/js/views/board_import_form_view.js
+++ b/client/js/views/board_import_form_view.js
@@ -1,0 +1,48 @@
+/**
+ * @fileOverview This file has functions related to organization board form view. This view calling from footer view.
+ * Available Object:
+ *	App.boards						: this object contain all boards(Based on logged in user)
+ *	this.model						: undefined.
+ */
+if (typeof App === 'undefined') {
+    App = {};
+}
+/**
+ * BoardImportForm View
+ * @class BoardImportFormView
+ * @constructor
+ * @extends Backbone.View
+ */
+App.BoardImportFormView = Backbone.View.extend({
+    tagName: 'ul',
+    className: 'list-unstyled',
+    /**
+     * Events
+     * functions to fire on events (Mouse events, Keyboard Events, Frame/Object Events, Form Events, Drag Events, etc...)
+     */
+    events: {},
+    /**
+     * Constructor
+     * initialize default values and actions
+     */
+    initialize: function() {
+        if (!_.isUndefined(this.model) && this.model !== null) {
+            this.model.showImage = this.showImage;
+        }
+        this.render();
+    },
+    template: JST['templates/board_import_form_view'],
+    /**
+     * render()
+     * populate the html to the dom
+     * @param NULL
+     * @return object
+     *
+     */
+    render: function() {
+        this.el = this.template({});
+        this.delegateEvents(this.events);
+        this.showTooltip();
+        return this;
+    }
+});


### PR DESCRIPTION
## Description
In the footer, the options for importing board is too large, have to display the Import board options separately issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
