### PR TITLE
Fixes #2330: twice activities are shown in the profile activities tab, While updating the profile picture in the settings tab issue fixed.

### DIFF
--- a/client/js/views/user_view.js
+++ b/client/js/views/user_view.js
@@ -290,6 +290,7 @@ App.UserView = Backbone.View.extend({
         var self = this;
         var form = $(e.target);
         var fileData = new FormData(form[0]);
+        fileData.delete("attachment");
         var data = $(e.target).serializeObject();
         data.default_desktop_notification = 'false';
         if ($("#default_desktop_notification").val() === 'Enabled') {


### PR DESCRIPTION

## Description
Fixes #2330: twice activities are shown in the profile activities tab, While updating the profile picture in the settings tab issue fixed.

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
