### PR TITLE
Fixes #2335: In modal card page, hover the total votes count - tooltip showing 'add a vote' and there is no tooltip shown for add vote link issue fixed.

### DIFF
--- a/client/js/templates/modal_card_view.jst.ejs
+++ b/client/js/templates/modal_card_view.jst.ejs
@@ -116,17 +116,17 @@
 							%>
 							<% if(_.isEmpty(voted_user)){  %>
 							  <% if(!_.isUndefined(authuser.user) && (authuser.user.role_id == 1 || !_.isEmpty(card.list.collection.board.acl_links.where({slug: "vote_card",board_user_role_id: parseInt(list.board_user_role_id)})))) { %>
-							  <button type="button" class="btn btn-primary js-add-card-vote no-print"><i class=" icon-thumbs-up"></i></button> 
+							  <button type="button" class="btn btn-primary js-add-card-vote no-print"  title="<%- i18next.t('Vote') %>"><i class=" icon-thumbs-up"></i></button> 
 							  <% } %>  
 							  <% } else{ %>
 							  <% if(!_.isUndefined(authuser.user) && (authuser.user.role_id == 1 || !_.isEmpty(card.list.collection.board.acl_links.where({slug: "unvote_card",board_user_role_id: parseInt(list.board_user_role_id)})))) { %>
-							  <button type="button" class="btn btn-default active js-delete-card-vote"><i class="  icon-thumbs-up"></i></button>  
+							  <button type="button" class="btn btn-default active js-delete-card-vote" title="<%- i18next.t('Unvote') %>"><i class="  icon-thumbs-up"></i></button>  
 							  <% } %>
 							  <% } }%>         
 					   </li>
 		          <% } %>
 					  
-					  <li class="dropdown"><a href="#" title="<%- i18next.t('Add Vote') %>" class="btn btn-default js-show-card-voters-list dropdown-toggle" data-toggle="dropdown"><%- i18next.t('{{count}} Vote', {count: card.card_voters.length}) %></a>
+					  <li class="dropdown"><a href="#" title="<%- i18next.t('{{count}} Vote', {count: card.card_voters.length}) %>" class="btn btn-default js-show-card-voters-list dropdown-toggle" data-toggle="dropdown"><%- i18next.t('{{count}} Vote', {count: card.card_voters.length}) %></a>
 						<ul class="dropdown-menu dropdown-menu-left arrow js-show-card-voters-list-response">
 						</ul>
 					  </li>


### PR DESCRIPTION

## Description
Fixes #2335: In modal card page, hover the total votes count - tooltip showing 'add a vote' and there is no tooltip shown for add vote link issue fixed.

## Related Issue
No

## Screenshots (if appropriate):
![screenshot-newtab-2019 02 05-18-10-17](https://user-images.githubusercontent.com/17172610/52274127-bcf92a80-2971-11e9-950f-fe048964fbac.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
