### PR TITLE
Fixes #2339: After click the 'Load more activities' in the profile page. activities are not loaded, "Load more activities" get hide issue fixed

### DIFF
--- a/client/js/views/user_view.js
+++ b/client/js/views/user_view.js
@@ -181,7 +181,11 @@ App.UserView = Backbone.View.extend({
                             return activity.id;
                         });
                         last_activity_id = last_activity.id;
-                        $('#js-user-activites-load-more').removeClass('hide');
+                        if (!response._metadata.noOfPages || response._metadata.noOfPages <= 1) {
+                            self.$('#js-user-activites-load-more').remove();
+                        } else {
+                            $('#js-user-activites-load-more').removeClass('hide');
+                        }
                         for (var i = 0; i < activities.models.length; i++) {
                             var activity = activities.models[i];
                             self.$('#js-user-activites').append(new App.UserActivityView({
@@ -578,6 +582,9 @@ App.UserView = Backbone.View.extend({
             cache: false,
             success: function(user, response) {
                 if (!_.isEmpty(activities) && !_.isEmpty(activities.models)) {
+                    if (!response._metadata.noOfPages || response._metadata.noOfPages <= 1) {
+                        self.$('#js-user-activites-load-more').remove();
+                    }
                     for (var i = 0; i < activities.models.length; i++) {
                         var activity = activities.models[i];
                         self.$('#js-user-activites').append(new App.UserActivityView({


### PR DESCRIPTION
## Description
Fixes #2339: After click the 'Load more activities' in the profile page. activities are not loaded, "Load more activities" get hide issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
