### PR TITLE
Fixes #2341 :  In Dashboard- Click profile icon - if hover shortcuts on the profile drop down - there is no tooltip label provided for the link.

### DIFF
--- a/client/js/templates/footer.jst.ejs
+++ b/client/js/templates/footer.jst.ejs
@@ -320,7 +320,7 @@ if (_.isEmpty(role_links.where({
 														</li>
 														<li class="divider"></li>
 														<li>
-															<a href="#" class="js-show-shortcuts-modal" data-toggle="modal" data-target="#ModalShortcutView">
+															<a href="#"  title="<%- i18next.t('Shortcuts') %>"  class="js-show-shortcuts-modal" data-toggle="modal" data-target="#ModalShortcutView">
 																<%- i18next.t('Shortcuts') %>
 															</a>
 														</li>


### PR DESCRIPTION
## Description
Fixes #2341 :  In Dashboard- Click profile icon - if hover shortcuts on the profile drop down - there is no tooltip label provided for the link.

## Related Issue
No

## Screenshots (if appropriate):
![screenshot-restyaplatform localhost-2019 02 06-12-55-01](https://user-images.githubusercontent.com/17172610/52326391-87eee580-2a0e-11e9-9091-51f50ef107b6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
