### PR TITLE
Fixes #2343: while clicking close icon, not able to close the delete dropdown menu of the particular user in the users listing page of admin panel  issue fixed

### DIFF
--- a/client/js/views/user_index_view.js
+++ b/client/js/views/user_index_view.js
@@ -22,6 +22,7 @@ App.UserIndex = Backbone.View.extend({
      * functions to fire on events (Mouse events, Keyboard Events, Frame/Object Events, Form Events, Drag Events, etc...)
      */
     events: {
+        'click .js-close-popover': 'closePopup',
         'click .js-user-activity-menu': 'userActivityMenu',
         'click .js-user-board-list': 'userBoardList',
         'click .js-no-action': 'noAction',
@@ -158,6 +159,20 @@ App.UserIndex = Backbone.View.extend({
         this.model.destroy();
         this.model.url = api_url + 'users/' + this.model.id + '.json';
         this.$el.remove();
+        return false;
+    },
+    /**
+     * closePopup()
+     * close the opend dropdown
+     * @param e
+     * @type Object(DOM event)
+     * @return false
+     *
+     */
+    closePopup: function(e) {
+        var el = this.$el;
+        var target = el.find(e.target);
+        target.parents('.dropdown').removeClass('open');
         return false;
     },
     /**


### PR DESCRIPTION
## Description
while clicking close icon, not able to close the delete dropdown menu of the particular user in the users listing page of admin panel  issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
