### PR TITLE
Fixes #2346 : while adding the new card, already created board labels are not listed based on search and empty spaces are accepts issue fixed.

### DIFF
--- a/client/js/views/card_view.js
+++ b/client/js/views/card_view.js
@@ -792,21 +792,23 @@ App.CardView = Backbone.View.extend({
         $('.js-card-action-list-response').html(new App.CardLabelsFormView({
             model: labels
         }).el);
-        if (_.isUndefined(labels)) {
+        if (_.isUndefined(labels) || _.isEmpty(labels)) {
             labels = [];
         } else {
             labels = labels.split(',');
         }
         var self = this;
         $('.inputCardLabel').select2({
-            tags: labels,
+            tags: _.uniq(self.model.collection.list.board.labels.pluck('name')),
             tokenSeparators: [',', ' ']
         }).on('select2-selecting', function(e) {
-            var labels = _.pluck(self.$('.inputCardLabel').select2('data'), 'text');
-            labels.push(e.choice.text);
-            self.$el.find('.js-card-add-labels').val(labels.join(','));
-            var iTag = '<i style="color:#' + calcMD5("" + e.choice.text).slice(0, 6).substring(0, 6) + '" data-toggle="tooltip" data-container="body" data-placement="top" data-original-title="' + e.choice.text + '" title="' + e.choice.text + '" class="js-label-' + e.choice.text + ' ' + LABEL_ICON + '"></i>';
-            $('.js-lables-list').append(iTag);
+            if (!_.isEmpty(e.choice.text)) {
+                var labels = _.pluck(self.$('.inputCardLabel').select2('data'), 'text');
+                labels.push(e.choice.text);
+                self.$el.find('.js-card-add-labels').val(labels.join(','));
+                var iTag = '<i style="color:#' + calcMD5("" + e.choice.text).slice(0, 6).substring(0, 6) + '" data-toggle="tooltip" data-container="body" data-placement="top" data-original-title="' + e.choice.text + '" title="' + e.choice.text + '" class="js-label-' + e.choice.text + ' ' + LABEL_ICON + '"></i>';
+                $('.js-lables-list').append(iTag);
+            }
         }).on('select2-removed', function(e) {
             var _labels = _.pluck(self.$('.inputCardLabel').select2('data'), 'text');
             self.$el.find('.js-card-add-labels').val(_labels.join(','));


### PR DESCRIPTION

## Description
Fixes #2346 : while adding the new card, already created board labels are not listed based on search and empty spaces are accepts issue fixed.

## Related Issue
No

## Screenshots (if appropriate):
![screenshot-restyaplatform localhost-2019 02 06-18-28-10](https://user-images.githubusercontent.com/17172610/52343286-a5877380-2a3d-11e9-91c1-99a4adb6e1a1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
