### PR TITLE
Fixes #2356: In the boards page, the boards link should not be shown in the footer boards button dropup menu issue fixed

### DIFF
--- a/client/js/templates/footer.jst.ejs
+++ b/client/js/templates/footer.jst.ejs
@@ -129,11 +129,13 @@ if (_.isEmpty(role_links.where({
 															<%
 			} 		
 		%>
-																<li class="clearfix js-boards-list-container-search">
+															<% if(!in_boards_page) { %>
+																<li class="clearfix js-boards-list-container-search js-a">
 																	<a href="#/boards" title="<%- i18next.t('Boards') %>">
 																		<%- i18next.t("Boards") %>
 																	</a>
 																</li>
+															<% } %>
 																<%
 
 			if (!_.isEmpty(role_links.where({

--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -187,12 +187,18 @@ App.FooterView = Backbone.View.extend({
                     });
                 });
             }
+            var in_boards_page = false;
+            var url = window.location.hash.split('/');
+            if (url.length === 2 && url['1'] === 'boards') {
+                in_boards_page = true;
+            }
             self.$el.html(self.template({
                 model: self.model,
                 board_id: self.board_id,
                 board: self.board,
                 languages: ($.cookie('languages')) ? $.cookie('languages').split(',') : null,
                 apps: getting_new_array,
+                'in_boards_page': in_boards_page,
                 converter: self.converter,
             }));
         });


### PR DESCRIPTION
## Description
In the boards page, the boards link should not be shown in the footer boards button dropup menu issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
