### PR TITLE
Fixes #2360: In the user profile page, under the cards tab, the user cards are shown with the field and the fields are not having their related title  issue fixed

### DIFF
--- a/client/js/templates/user_cards.jst.ejs
+++ b/client/js/templates/user_cards.jst.ejs
@@ -22,31 +22,31 @@
 					<div class="panel-body"> 
 						<ul class="list-inline navbar-btn clearfix js-open-model-car-view" data-id="<%- user_card.id%>">
 							<li class="col-md-1 col-xs-2"><span class="card-id">#<%- user_card.id%></span></li>
-							<li class="col-md-4 col-xs-3 js-open-model-car-view" data-id="<%- user_card.id%>"><%- user_card.attributes.name %></li> 
-							<li class="col-md-4 col-xs-3"><%- user_card.attributes.list_name %></li>
+							<li class="col-md-4 col-xs-3"><span class="js-open-model-car-view" data-id="<%- user_card.id%>" title="<%- user_card.attributes.name %>"><%- user_card.attributes.name %></span></li> 
+							<li class="col-md-4 col-xs-3"><span title="<%- user_card.attributes.list_name %>"><%- user_card.attributes.list_name %></span></li>
 							<li class="col-md-3 col-xs-4">
 								<ul class="list-inline text-muted clearfix">
 									<% if(user_card.attributes.cards_subscriber_count > 0){ %>
-										<li><small><span class="icon-eye-open"></span></small></li>
+										<li><small title="<%- i18next.t('Subscribed') %>"><span class="icon-eye-open"></span></small></li>
 									<% } %> 
 									<% if(user_card.attributes.card_voter_count > 0){ %>
-									<li><small><span class="icon-thumbs-up"></span><span><%- user_card.attributes.card_voter_count %></span></small></li>
+									<li><small title="<%- i18next.t('{{count}} Vote', {count: user_card.attributes.card_voter_count}) %>"><span class="icon-thumbs-up"></span><span><%- user_card.attributes.card_voter_count %></span></small></li>
 									<% } %>
 									<% if(user_card.attributes.comment_count > 0){ %>
-										<li><small><span class="icon-comment"></span><span><%- user_card.attributes.comment_count %></span></small></li>
+										<li><small title="<%- i18next.t('{{count}} Comment', {count: user_card.attributes.comment_count}) %> "><span class="icon-comment"></span><span><%- user_card.attributes.comment_count %></span></small></li>
 									<% } %>
 									<% if(!_.isEmpty(user_card.attributes.description)){ %>
-										<li><small><span class="icon-align-left"></span><span></span></small></li>
+										<li><small title="<%- i18next.t('Description') %>"><span class="icon-align-left"></span><span></span></small></li>
 									<% } %>
 									<% if(user_card.attributes.checklist_item_count > 0){ %>
-										<li><small><% if(user_card.attributes.checklist_item_completed_count == user_card.attributes.checklist_item_count) { %><div class="label label-success"> <% } %><span class="icon-list-ul"></span><span><%- user_card.attributes.checklist_item_completed_count %>/<%- user_card.attributes.checklist_item_count %></span><% if(user_card.attributes.checklist_item_completed_count == user_card.attributes.checklist_item_count) { %></div><% } %></small></li>
+										<li><small title="<%- i18next.t('%s checklist completed out of %s', { postProcess: 'sprintf', sprintf: [user_card.attributes.checklist_item_completed_count, user_card.attributes.checklist_item_count]}) %> "><% if(user_card.attributes.checklist_item_completed_count == user_card.attributes.checklist_item_count) { %><div class="label label-success"> <% } %><span class="icon-list-ul"></span><span><%- user_card.attributes.checklist_item_completed_count %>/<%- user_card.attributes.checklist_item_count %></span><% if(user_card.attributes.checklist_item_completed_count == user_card.attributes.checklist_item_count) { %></div><% } %></small></li>
 									<% } %> 
 									<% if(user_card.attributes.due_date > 0){ %>
-										<li><small><span class="icon-time"></span><span><%- user_card.attributes.due_date %></span></small></li>
+										<li><small title="<%- i18next.t('Due Date') %>"><span class="icon-time"></span><span><%- user_card.attributes.due_date %></span></small></li>
 									<% } %> 
 									<% if(user_card.attributes.attachment_count > 0){ %>
 										<li>
-											<small>
+											<small title="<%- i18next.t('{{count}} Attachment', {count: user_card.attributes.attachment_count}) %> ">
 												<span class="icon-paper-clip"></span>
 												<span>
 												<%- user_card.attributes.attachment_count %>


### PR DESCRIPTION
## Description
In the user profile page, under the cards tab, the user cards are shown with the field and the fields are not having their related title  issue fixed

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
