### PR TITLE
Fixes #2347: While installing the Restyaboard in the Centos with the installation script, the PHP gd is not installed issue fixed

### DIFF
--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -895,6 +895,7 @@
 
 					yum install -y ImageM* netpbm gd gd-* libjpeg libexif gcc coreutils make
 					yum install -y php72w-pear
+					yum install -y php72w-gd
 					error_code=$?
 					if [ ${error_code} != 0 ]
 					then


### PR DESCRIPTION
## Description
 While installing the Restyaboard in the Centos with the installation script, the PHP gd is not installed issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
