### PR TITLE
Fixes  #2385: In modal card page, comment button disabled when give te space and after give the value, comment button not enabled issue fixed.

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -2716,6 +2716,7 @@ App.ModalCardView = Backbone.View.extend({
         if (!$.trim($(e.target).find('#inputAddComment').val()).length) {
             $(e.target).find('.error-msg').remove();
             $('<div class="error-msg text-primary h6">Whitespace is not allowed</div>').insertAfter($(e.target).find('#inputAddComment'));
+            $('#submitCommentAdd').removeClass('disabled');
         } else {
             $(e.target).find('.error-msg').remove();
             var self = this;


### PR DESCRIPTION

## Description
Fixes  #2385: In modal card page, comment button disabled when give te space and after give the value, comment button not enabled issue fixed.

## Related Issue
No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
