### PR TITLE
The postfix relayhost does not work in the docker container.

### DIFF
--- a/docker-scripts/docker-entrypoint.sh
+++ b/docker-scripts/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'start' ]; then
       -e '$ a myorigin = $mydomain' \
       -e '$ a mydestination = localhost, $myhostname, localhost.$mydomain' \
       -e '$ a sender_canonical_maps = hash:/etc/postfix/sender_canonical' \
-      -e "s/#relayhost =.*$/relayhost = [${SMTP_SERVER}]:${SMTP_PORT}/" \
+      -e "s/relayhost =.*$/relayhost = [${SMTP_SERVER}]:${SMTP_PORT}/" \
       -e '/smtp_.*/d' \
       -e '$ a smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache' \
       -e '$ a smtp_sasl_auth_enable = yes' \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the docker-entrypoint.sh, it does not work to change the postfix relayhost setting in /etc/postfix/main.cf.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For the SMTP setting with the docker container, it should be fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested it with docker build and run the docker container on kubernetes.
<!--- Include details of your testing environment, and the tests you ran to -->
The environment is Kubernetes 1.13.0.
<!--- see how your change affects other areas of the code, etc. -->
Meybe, it does not any affect other areas.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
