### PR TITLE
Fixes #2404: While drag and drop from the card from the list with wip limit to the empty, the wip limit is also copied to the new list issue fixed

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1177,6 +1177,7 @@ App.ListView = Backbone.View.extend({
         var self = this;
         if (!_.isUndefined(e) && e.storeName === 'card') {
             if (e.attributes.list_id === self.model.id) {
+                e.attributes.triggersort = true;
                 var view = new App.CardView({
                     tagName: 'div',
                     model: e,


### PR DESCRIPTION
## Description
While drag and drop from the card from the list with wip limit to the empty, the wip limit is also copied to the new list issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
