### PR TITLE
Fixes #2424: In board member activity modal page, after reaching the "paging count" only, "load more activities" button should be displayed issue fixed

### DIFF
--- a/client/js/views/modal_user_activities_list_view.js
+++ b/client/js/views/modal_user_activities_list_view.js
@@ -72,13 +72,13 @@ App.ModalUserActivitiesListView = Backbone.View.extend({
         var activities = new App.ActivityCollection();
         activities.url = api_url + 'users/' + this.user_id + '/activities.json?board_id=' + this.model.attributes.board_id;
         activities.fetch({
-            success: function(response) {
+            success: function(model, response) {
                 if (!_.isEmpty(activities.models)) {
                     var last_activity = _.min(activities.models, function(activity) {
                         return activity.id;
                     });
                     self.last_activity_id = last_activity.id;
-                    self.$('#js-admin-activites-load-more').removeClass('hide');
+                    self.model.set('activity_count', response._metadata.total_records);
                     self.renderActivitiesCollection(activities);
                 } else {
                     var view = new App.ActivityView({
@@ -141,6 +141,9 @@ App.ModalUserActivitiesListView = Backbone.View.extend({
         var view_user_activities = this.$('#js-list-user-activities-list');
         view_user_activities.html('');
         if (!_.isEmpty(activities)) {
+            if (self.model.attributes.activity_count != PAGING_COUNT && activities.models.length >= PAGING_COUNT) {
+                self.$('#js-admin-activites-load-more').removeClass('hide');
+            }
             for (var i = 0; i < activities.models.length; i++) {
                 var activity = activities.models[i];
                 activity.from_footer = true;

--- a/client/js/views/user_index_container_view.js
+++ b/client/js/views/user_index_container_view.js
@@ -80,7 +80,7 @@ App.UserIndexContainerView = Backbone.View.extend({
                 roles: this.roles
             }));
         }
-        
+
         if (!_.isUndefined(this.sortField)) {
             this.renderUserCollection();
         }


### PR DESCRIPTION
## Description
In board member activity modal page, after reaching the "paging count" only, "load more activities" button should be displayed issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
