### PR TITLE
Fixes #2322: Large space between the Add card input and the save button in the Add card form of the list issue fixed

### DIFF
--- a/client/js/templates/card_add.jst.ejs
+++ b/client/js/templates/card_add.jst.ejs
@@ -11,13 +11,13 @@
 	<div class="form-group">
 		<textarea placeholder=" <%- i18next.t('Add a card') %>" rows="3" id="AddCard" class="form-control" name="name" required><%- name %></textarea> 
 	</div>
-	<div class="row js-users-list">
+	<div class="row js-users-list hide">
 		<ul class="list-unstyled list-inline text-muted clearfix"></ul>
 	</div>
-	<div class="row js-checklist-list">
+	<div class="row js-checklist-list hide">
 		<ul class="list-unstyled list-inline text-muted clearfix"></ul>
 	</div>
-	<div class="row js-custom_fields-list">
+	<div class="row js-custom_fields-list hide">
 		<ul class="list-unstyled list-inline text-muted clearfix"></ul>
 	</div>
 	<div class="row">     


### PR DESCRIPTION
## Description
Large space between the Add card input and the save button in the Add card form of the list issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
