### PR TITLE
Fixes #2520: While adding and removing list color, overall list get reloaded for the current user and other users in another browser issue fixed.

### DIFF
--- a/client/js/templates/list_actions.jst.ejs
+++ b/client/js/templates/list_actions.jst.ejs
@@ -60,9 +60,9 @@
     <li class="list-inline js-change-color js-list-color-pick navbar-btn cur" data-color="#ccdc87"><span class="btn btn-default show well-sm" style="background-color:#ccdc87"></span></li>
     <li class="list-inline js-change-color js-list-color-pick navbar-btn cur" data-color="#f1eabf"><span class="btn btn-default show well-sm" style="background-color:#f1eabf"></span></li>
     <% if(!_.isEmpty(list.attributes.color)){ %>
-        <button type="button" class="btn btn-primary js-remove-list-color">Remove color</button>
+        <button type="button" class="btn btn-primary js-remove-list-color"  id="js-remove-list-color-<%- list.id %>">Remove color</button>
     <% }else{ %>
-        <button type="button" class="hide btn btn-primary js-remove-list-color">Remove color</button>
+        <button type="button" class="hide btn btn-primary js-remove-list-color"  id="js-remove-list-color-<%- list.id %>">Remove color</button>
     <% } %>
   </ul><div class="well-sm"></div></div></li>
 

--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -56,8 +56,9 @@ App.ListView = Backbone.View.extend({
         if (this.model.has('board_activities')) {
             this.board_activites = this.model.collection.board.get('board_activities');
         }
-        _.bindAll(this, 'render', 'renderCardsCollection', 'removeRender');
-        this.model.bind('change:name change:color add:color remove:color', this.render);
+        _.bindAll(this, 'render', 'renderCardsCollection', 'removeRender', 'colorListviewcollection');
+        this.model.bind('change:name', this.render);
+        this.model.bind('change:color add:color remove:color', this.colorListviewcollection);
         if (!_.isUndefined(this.model.collection)) {
             this.model.collection.board.labels.bind('add', this.renderCardsCollection);
             this.model.collection.board.attachments.bind('add', this.renderCardsCollection);
@@ -956,6 +957,26 @@ App.ListView = Backbone.View.extend({
             }
         }).defer();
         return false;
+    },
+    /**
+     * colorListviewcollection()
+     * Bidding the color for list
+     * @param NULL
+     * @return object
+     *
+     */
+    colorListviewcollection: function() {
+        var self = this;
+        var list_id = self.model.id,
+            color = self.model.attributes.color;
+        $('#js-list-color-' + list_id).attr('style', 'background-color: ' + color + ' !important');
+        $('#js-list-demo-' + list_id).attr('style', 'border-bottom: 2px solid' + color + ' !important');
+        if (!_.isUndefined(color) && !_.isEmpty(color) && color !== null) {
+            $('#js-remove-list-color-' + list_id).removeClass('hide');
+        } else {
+            $('#js-list-demo-' + list_id).attr('style', 'border-bottom: ' + color);
+            $('#js-remove-list-color-' + list_id).addClass('hide');
+        }
     },
     /**
      * render()


### PR DESCRIPTION
## Description
While adding and removing list color, the overall list gets reloaded for the current user and other users in another browser issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
