### PR TITLE
Fixes #2541: View member's board activity - after clicking the "load more activities", previous activities are removed issue fixed.

### DIFF
--- a/client/js/views/modal_user_activities_list_view.js
+++ b/client/js/views/modal_user_activities_list_view.js
@@ -140,7 +140,6 @@ App.ModalUserActivitiesListView = Backbone.View.extend({
     renderActivitiesCollection: function(activities) {
         var self = this;
         var view_user_activities = this.$('#js-list-user-activities-list');
-        view_user_activities.html('');
         if (!_.isEmpty(activities)) {
             if (self.model.attributes.activity_count != PAGING_COUNT && activities.models.length >= PAGING_COUNT) {
                 self.$('#js-admin-activites-load-more').removeClass('hide');


### PR DESCRIPTION
## Description
View member's board activity - after clicking the "load more activities", previous activities are removed issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
