### PR TITLE
Fixes #2570: User in the board Gantt view, After clicking the new board in the footer, its redirect to Gantt view of the new board issue fixed.

### DIFF
--- a/client/js/views/application_view.js
+++ b/client/js/views/application_view.js
@@ -443,6 +443,7 @@ App.ApplicationView = Backbone.View.extend({
                                 $('#content .js-boards-view').remove('');
                                 $('#content').html('<section id="boards-view-' + view_type + '" class="clearfix js-boards-view"></section>');
                             }).defer();
+                            view_type = null;
                         } else if (view_type === null || view_type === '') {
                             $('.js-switch-grid-view').trigger('click');
                             view_type = null;


### PR DESCRIPTION
## Description
User in the board Gantt view, After clicking the new board in the footer, its redirect to Gantt view of the new board issue are fixed 

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
