### PR TITLE
Fixes #2587: Console error ReferenceError:is_send_newsletter_val is not defined thrown in the admin user add page issue fixed

### DIFF
--- a/client/js/views/admin_user_add_view.js
+++ b/client/js/views/admin_user_add_view.js
@@ -130,7 +130,7 @@ App.AdminUserAddView = Backbone.View.extend({
                     var split = repo.text.split(',');
                     return split[0];
                 },
-            }).select2('val', is_send_newsletter_val);
+            }).select2('val', '');
         }).defer();
         return this;
     }


### PR DESCRIPTION
## Description
Console error ReferenceError:is_send_newsletter_val is not defined thrown in the admin user add page issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
