### PR TITLE
Fixes #2590: While creating the checklist in the modal card page, if we select the checklist name using the mouse drag, the Add checklist form is closed issue fixed

### DIFF
--- a/client/js/templates/checklist_add_form.jst.ejs
+++ b/client/js/templates/checklist_add_form.jst.ejs
@@ -63,5 +63,5 @@
 <% } %>
 <div class="form-group">
 	<label for="submit" class="sr-only col-sm-4 control-label"><%- i18next.t('submit') %></label>
-	<input type="submit" name="Save" class="btn btn-primary" value="<%- i18next.t('Add') %>">
+	<input type="submit" name="Save" class="btn btn-primary js-checklist-add-submit" value="<%- i18next.t('Add') %>">
 </div>

--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -58,6 +58,7 @@ App.ModalCardView = Backbone.View.extend({
         'click a.js-attachment-computer-open': 'computerOpen',
         'change .js-card-attachment': 'addCardAttachment',
         'click .js-show-checklist-add-form': 'showChecklistAddForm',
+        'click .js-checklist-add-form-response': 'preventDefault',
         'submit form.js-add-checklist': 'addChecklist',
         'click .js-show-add-member-form': 'showAddMemberForm',
         'click .js-add-card-member': 'addCardMember',
@@ -3055,6 +3056,13 @@ App.ModalCardView = Backbone.View.extend({
         $('li.dropdown').removeClass('open');
         target.parents('li.dropdown').addClass('open');
         return false;
+    },
+    preventDefault: function(e) {
+        var target_class = $(e.target).attr('class');
+        if (!_.isUndefined(target_class) && target_class.indexOf('js-checklist-add-submit') === -1) {
+            e.preventDefault();
+            return false;
+        }
     },
     /**
      * addChecklist()


### PR DESCRIPTION
## Description
While creating the checklist in the modal card page, if we select the checklist name using the mouse drag, the Add checklist form is closed issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
