### PR TITLE
Fixes #1771:  Can't send email from Azure hosting notified information added while installation through a shell script

### DIFF
--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -1560,6 +1560,12 @@
 			esac
 		fi
 		set +x
+		echo "Checking Hosting..."
+		response=$(curl -H Metadata:true http://169.254.169.254/metadata/instance?api-version=2017-04-02 --write-out %{http_code} --connect-timeout 10 --max-time 10 --silent --output /dev/null)
+		if [ ${response} -eq 200 ];then
+			echo "Note: PHP Mailer will not work in Azure. Kindly use external SMTP mail server."
+		fi
+		set +x
 		curl -v -L -G -d "app=board&os=${os}&version=${version}" "http://restya.com/success_installation.php"
 		echo "Restyaboard URL : $webdir"
 


### PR DESCRIPTION
## Description
Can't send email from Azure hosting notified information added while installation through a shell script

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
