### PR TITLE
Fixes #2605: While using the card counter app to show the number of cards in the lists, if the list has a large number of cards, the number of cards displayed after loading all cards only issue fixed

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1265,7 +1265,8 @@ App.ListView = Backbone.View.extend({
         this.converter.setFlavor('github');
         var filtered_cards = '';
         var self = this;
-
+        this.renderCardNumbers();
+        
         if (!_.isUndefined(e) && e.storeName === 'card') {
             if (e.attributes.list_id === self.model.id) {
                 e.attributes.triggersort = true;
@@ -1430,7 +1431,6 @@ App.ListView = Backbone.View.extend({
                 });
             }
         }
-        this.renderCardNumbers();
     },
 
     renderCardNumbers: function() {


### PR DESCRIPTION
## Description
While using the card counter app to show the number of cards in the lists, if the list has a large number of cards, the number of cards displayed after loading all cards only issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
