### PR TITLE
Fixes #2651: While move or copy card to another board, the custom fields are not copied along with dropdown option to that card  issue fixed.

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -6531,7 +6531,7 @@ function r_put($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_put)
                             $r_put['board_id'],
                             $custom_field['name']
                         );
-                        $customField = executeQuery('SELECT id FROM custom_fields WHERE board_id = $1 AND name = $2', $qry_val_arr);
+                        $customField = executeQuery('SELECT * FROM custom_fields WHERE board_id = $1 AND name = $2', $qry_val_arr);
                         if (empty($customField)) {
                             $data = array(
                                 'user_id' => $authUser['id'],
@@ -6549,6 +6549,23 @@ function r_put($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_put)
                             $row = pg_fetch_assoc($result);
                             $customFields[$custom_field['id']] = (int)($row['id']);
                         } else {
+                            $qry_val_arr = array(
+                                $previous_value['board_id'],
+                                $custom_field['name']
+                            );
+                            $previous_customField = executeQuery('SELECT * FROM custom_fields WHERE board_id = $1 AND name = $2', $qry_val_arr);
+                            if (!empty($previous_customField) && !empty($customField)) {
+                                if ($previous_customField['type'] === 'dropdown') {
+                                    $new_customfield_options = explode(',', $customField['options']);
+                                    $previous_customfield_options = explode(',', $previous_customField['options']);
+                                    $new_unique_option = array_unique(array_merge($new_customfield_options, $previous_customfield_options));
+                                    $data = array(
+                                        $customField['id'],
+                                        implode(',', $new_unique_option)
+                                    );
+                                    pg_query_params($db_lnk, 'UPDATE custom_fields SET options = $2 WHERE id = $1', $data);
+                                }
+                            }
                             $customFields[$custom_field['id']] = $customField['id'];
                         }
                     } else {


### PR DESCRIPTION
## Description
While move or copy card to another board, the custom fields are not copied along with the dropdown option to that card issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
