### PR TITLE
Fixes #2681: In Gantt board view page, Out of theme, background color  are showing issue are fixed.

### DIFF
--- a/client/css/custom.less
+++ b/client/css/custom.less
@@ -1536,7 +1536,6 @@ footer, header, .dashboard-header {
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
-	background-color: #f3f5f7;
 }
 .gantt:after {
 	content: ".";


### PR DESCRIPTION
## Description
In Gantt board view page, Out of theme, background color  are showing issue are fixed

## Related Issue
No
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
