### PR TITLE
Fixes #2703: `Cannot read property 'options' of undefined ` error throwing while popout the modal card page issue fixed.

### DIFF
--- a/client/js/libs/jquery.dockmodal.js
+++ b/client/js/libs/jquery.dockmodal.js
@@ -422,19 +422,21 @@
                 if ($dockModal.hasClass("popped-out") && !$dockModal.hasClass("minimized")) {
                     return;
                 }
-                right += $this.options.gutter;
-                $dockModal.css({ "right": right + "px" });
-                if ($dockModal.hasClass("minimized")) {
-                    right += $this.options.minimizedWidth;
-                } else {
-                    right += $this.options.width;
-                }
-                if (right > windowWidth) {
-                    $dockModal.hide();
-                } else {
-                    setTimeout(function () {
-                        $dockModal.show();
-                    }, $this.options.animationSpeed);
+                if($this.options !== undefined){
+                    right += $this.options.gutter;
+                    $dockModal.css({ "right": right + "px" });
+                    if ($dockModal.hasClass("minimized")) {
+                        right += $this.options.minimizedWidth;
+                    } else {
+                        right += $this.options.width;
+                    }
+                    if (right > windowWidth) {
+                        $dockModal.hide();
+                    } else {
+                        setTimeout(function () {
+                            $dockModal.show();
+                        }, $this.options.animationSpeed);
+                    }
                 }
             });
         }


### PR DESCRIPTION
## Description
`Cannot read property 'options' of undefined ` error throwing while popout the modal card page issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
