### PR TITLE
Fixes #2712: TypeErrork</a.prototype.silence(default.cache) `this._atop is null` error is throwing while entering the board view page issue fixed.

### DIFF
--- a/client/js/libs/musical.js
+++ b/client/js/libs/musical.js
@@ -161,7 +161,9 @@ var Instrument = (function() {
     // Disconnect the audio graph for this instrument.
     if (this._out) {
       this._out.disconnect();
-      initvolume = this._out.gain.value;
+      if(this._out){
+        initvolume = this._out.gain.value;
+      }
     }
 
     // Reinitialize the audio graph: all audio for the instrument


### PR DESCRIPTION
## Description
TypeErrork</a.prototype.silence(default.cache) `this._atop is null` error is throwing while entering the board view page issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
