### PR TITLE
Fixes #2717: TypeError?(default.cache)` Cannot read property 'cards' of undefined` error throwing while dragging the card from one list to another list issue fixed.

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -2122,12 +2122,14 @@ App.BoardHeaderView = Backbone.View.extend({
             var filter_query = dictFilter.filter_query;
             if (_.isEmpty(arrays) && _.isEmpty(filter_query)) {
                 _.each(this.model.lists.models, function(list) {
-                    var cards = self.model.cards.filter(function(card) {
-                        return card.get('is_archived') !== 1 && card.get('list_id') === parseInt(list.id);
-                    });
-                    _.each(cards, function(card, key) {
-                        card.set('is_filtered', false);
-                    });
+                    if (!_.isUndefined(self.model.cards) && !_.isEmpty(self.model.cards)) {
+                        var cards = self.model.cards.filter(function(card) {
+                            return card.get('is_archived') !== 1 && card.get('list_id') === parseInt(list.id);
+                        });
+                        _.each(cards, function(card, key) {
+                            card.set('is_filtered', false);
+                        });
+                    }
                 });
             }
             if (!_.isEmpty(arrays) && !_.isEmpty(filter_query)) {


### PR DESCRIPTION

## Description
TypeError?(default.cache)` Cannot read property 'cards' of undefined` error throwing while dragging the card from one list to another list issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
