### PR TITLE
Fixes #2740: Restoring archived cards do not restore labels until refresh issue fixed

### DIFF
--- a/client/js/views/archived_card_view.js
+++ b/client/js/views/archived_card_view.js
@@ -60,6 +60,14 @@ App.ArchivedCardView = Backbone.View.extend({
             card.list = self.model.board.lists.findWhere({
                 id: card.attributes.list_id
             });
+            var filter_labels = self.model.board.labels.filter(function(model) {
+                return parseInt(model.get('card_id')) === parseInt(self.model.id);
+            });
+            var labels = new App.CardLabelCollection();
+            labels.add(filter_labels, {
+                silent: true
+            });
+            card.labels = labels;
             new App.CardView({
                 model: card
             }).showCardModal();


### PR DESCRIPTION
## Description
Restoring archived cards do not restore labels until refresh issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
