### PR TITLE
Fixes #2740: Restoring archived cards do not restore labels until refresh issue fixed.

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1380,16 +1380,16 @@ App.ListView = Backbone.View.extend({
                 }
                 cards.each(function(card) {
                     var card_id = card.id;
+                    var filter_labels = self.model.labels.filter(function(model) {
+                        return parseInt(model.get('card_id')) === parseInt(card_id);
+                    });
+                    var labels = new App.CardLabelCollection();
+                    labels.add(filter_labels, {
+                        silent: true
+                    });
+                    card.labels = labels;
                     if (parseInt(card.get('is_archived')) === 0) {
                         card.board_users = self.model.board_users;
-                        var filter_labels = self.model.labels.filter(function(model) {
-                            return parseInt(model.get('card_id')) === parseInt(card_id);
-                        });
-                        var labels = new App.CardLabelCollection();
-                        labels.add(filter_labels, {
-                            silent: true
-                        });
-                        card.labels = labels;
                         card.card_voters.add(card.get('card_voters'), {
                             silent: true
                         });


### PR DESCRIPTION
## Description
Restoring archived cards do not restore labels until refresh issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
