### PR TITLE
Fixes #2753: While changing the position the more than one list in the board view page, after refresh position lists are reset into the previous position issue are fixed.

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -182,6 +182,7 @@ App.ListView = Backbone.View.extend({
                         }
                     });
                 }
+                self.model.collection.sortByColumn('position');
             }
         });
     },


### PR DESCRIPTION

## Description
While changing the position the more than one list in the board view page, after refresh position lists are reset into the previous position issue are fixed.

## Related Issue
No
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
