### PR TITLE
Fixes #2758: Rarely the Keep custom fields option is not showing in the copy card form issue fixed

### DIFF
--- a/client/js/templates/copy_card.jst.ejs
+++ b/client/js/templates/copy_card.jst.ejs
@@ -1,4 +1,4 @@
-<%        if (card.attachments.length > 0 || card.activities.length > 0 || card.labels.length > 0 || card.checklists.length > 0 || card.users.length > 0) { %>
+<% if (card.attachments.length > 0 || card.activities.length > 0 || card.labels.length > 0 || card.checklists.length > 0 || card.users.length > 0 || (!_.isUndefined(APPS) && APPS !== null && !_.isUndefined(APPS.enabled_apps) && APPS.enabled_apps !== null && $.inArray('r_custom_fields', APPS.enabled_apps) !== -1)) { %>
 		<div class="form-group">
 			<h4> <%- i18next.t('Keep...') %></h4>
 			<% if (card.attachments.length > 0) {%>


### PR DESCRIPTION
## Description
Rarely the Keep custom fields option is not showing in the copy card form issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
