### PR TITLE
Fixes #2761: ReferenceError `label is not defined` error throwing while showing the due date in front of the card issue fixed

### DIFF
--- a/client/js/templates/card.jst.ejs
+++ b/client/js/templates/card.jst.ejs
@@ -86,6 +86,7 @@
 		var diff = Math.floor(due_date.getTime() - today.getTime());
 		var day = 1000 * 60 * 60 * 24;
 		var days = Math.floor(diff / day);
+		var label;
 		if (days < -1) {
 			label = 'label-danger';
 		} else if (days == -1) {
@@ -94,8 +95,10 @@
 			label = 'label-future';
 		}
 	%>
+	<% if(!_.isUndefined(label) && !_.isEmpty(label) && label != null) { %>
 	<li class="card-listing-truncate"><small title=" <%- i18next.t('Due Date') %>"><span class="label <%- label %>"><%= dateFormat(date_time[0], 'mediumDate')  %></span></small></li>
-	<% } %>
+	<% }
+		} %>
 	<% if(!_.isEmpty(card.attributes.created) && card.attributes.created != 'NULL'){
 			var created_date_time = card.attributes.created.split('T');
 			created_date_time = created_date_time[0].split(' ');


### PR DESCRIPTION
## Description
ReferenceError `label is not defined` error throwing while showing the due date in front of the card issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
