### PR TITLE
Fixes #2765: TypeError `Cannot read property created of undefined` error thrown while adding the card using the add card option in the list issue fixed

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1680,9 +1680,11 @@ App.ListView = Backbone.View.extend({
             $('#js-card-listing-' + this.model.id).scrollTop($('#js-card-listing-' + this.model.id)[0].scrollHeight);
             card.save(data, {
                 success: function(model, response, options) {
-                    card.set('created', response.activity.created);
-                    card.set('card_created_user', response.activity.full_name);
-                    card.set('description', response.activity.card_description);
+                    if (!_.isUndefined(response) && !_.isEmpty(response) && response !== null && !_.isUndefined(response.activity) && !_.isEmpty(response.activity) && response.activity !== null) {
+                        card.set('created', response.activity.created);
+                        card.set('card_created_user', response.activity.full_name);
+                        card.set('description', response.activity.card_description);
+                    }
                     if (!_.isUndefined(response.cards_custom_fields) && !_.isEmpty(response.cards_custom_fields)) {
                         card.set('cards_custom_fields', response.cards_custom_fields);
                     }


### PR DESCRIPTION
## Description
TypeError `Cannot read property created of undefined` error thrown while adding the card using the add card option in the list issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
