### PR TITLE
Fixes #2769: TypeError `Failed to construct Notification` error thrown while user to enable the desktop notification issue fixed

### DIFF
--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -2295,17 +2295,19 @@ App.FooterView = Backbone.View.extend({
     enabledesktopNotification: function(e) {
         e.preventDefault();
         var self = this;
-        Notification.requestPermission(function(permission) {
-            // Whatever the user answers, we make sure we store the information
-            if (!('permission' in Notification)) {
-                Notification.permission = permission;
-            }
-            // If the user is okay, let's create a notification
-            if (permission === 'granted') {
-                var notification = new Notification('Desktop notification enabled.');
-                location.reload();
-            }
-        });
+        if (!_.isUndefined(Notification)) {
+            Notification.requestPermission(function(permission) {
+                // Whatever the user answers, we make sure we store the information
+                if (!('permission' in Notification)) {
+                    Notification.permission = permission;
+                }
+                // If the user is okay, let's create a notification
+                if (permission === 'granted') {
+                    var notification = new Notification('Desktop notification enabled.');
+                    location.reload();
+                }
+            });
+        }
     },
     /**
      * showBoardImportForm()

--- a/client/js/views/user_view.js
+++ b/client/js/views/user_view.js
@@ -81,17 +81,19 @@ App.UserView = Backbone.View.extend({
     enabledesktopNotification: function(e) {
         e.preventDefault();
         var self = this;
-        Notification.requestPermission(function(permission) {
-            // Whatever the user answers, we make sure we store the information
-            if (!('permission' in Notification)) {
-                Notification.permission = permission;
-            }
-            // If the user is okay, let's create a notification
-            if (permission === 'granted') {
-                var notification = new Notification('Desktop notification enabled.');
-                location.reload();
-            }
-        });
+        if (!_.isUndefined(Notification)) {
+            Notification.requestPermission(function(permission) {
+                // Whatever the user answers, we make sure we store the information
+                if (!('permission' in Notification)) {
+                    Notification.permission = permission;
+                }
+                // If the user is okay, let's create a notification
+                if (permission === 'granted') {
+                    var notification = new Notification('Desktop notification enabled.');
+                    location.reload();
+                }
+            });
+        }
     },
     /** 
      * TriggerSettingtab()


### PR DESCRIPTION
## Description
TypeError `Failed to construct Notification` error thrown while user to enable the desktop notification issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
