### PR TITLE
Fixes #2771: TypeError `Cannot read property cards of undefined` error thrown while clearing the filter in the board page issue fixed

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -2347,12 +2347,14 @@ App.BoardHeaderView = Backbone.View.extend({
             filter = '/' + filter;
         }
         _.each(this.model.lists.models, function(list) {
-            var cards = self.model.cards.filter(function(card) {
-                return card.get('is_archived') !== 1 && card.get('list_id') === parseInt(list.id);
-            });
-            _.each(cards, function(card, key) {
-                card.set('is_filtered', false);
-            });
+            if (!_.isUndefined(self.model.cards) && !_.isEmpty(self.model.cards) && self.model.cards !== null) {
+                var cards = self.model.cards.filter(function(card) {
+                    return card.get('is_archived') !== 1 && card.get('list_id') === parseInt(list.id);
+                });
+                _.each(cards, function(card, key) {
+                    card.set('is_filtered', false);
+                });
+            }
             if (list.attributes.card_count !== 0 && $('#js-card-listing-' + list.id).find('.js-list-placeholder-' + list.id).length > 0) {
                 $('#js-card-listing-' + list.id).find('.js-list-placeholder-' + list.id).remove();
             }


### PR DESCRIPTION
## Description
TypeError `Cannot read property cards of undefined` error thrown while clearing the filter in the board page issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
