### PR TITLE
Dropbox is not defined while adding Dropbox attachment in modal card solved

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -2514,7 +2514,7 @@ App.ModalCardView = Backbone.View.extend({
             linkType: 'preview',
             multiselect: true
         };
-        if (!_.isUndefined(Dropbox)){
+        if (!_.isUndefined(Dropbox)) {
             Dropbox.init({
                 appKey: DROPBOX_APPKEY
             });

--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -2514,10 +2514,12 @@ App.ModalCardView = Backbone.View.extend({
             linkType: 'preview',
             multiselect: true
         };
-        Dropbox.init({
-            appKey: DROPBOX_APPKEY
-        });
-        Dropbox.choose(options);
+        if (!_.isUndefined(Dropbox)){
+            Dropbox.init({
+                appKey: DROPBOX_APPKEY
+            });
+            Dropbox.choose(options);
+        }
         return false;
     },
     /**


### PR DESCRIPTION
## Description
Dropbox is not defined while adding Dropbox attachment in modal card solved

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
