### PR TITLE
Fixes #2773:  Swagger documentation not available when installed using docker-compose issue fixed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
- FROM php:7-cli as builder
+FROM php:7-cli as builder
 
 RUN apt-get update
 RUN apt-get install -y gnupg2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-cli as builder
+ FROM php:7-cli as builder
 
 RUN apt-get update
 RUN apt-get install -y gnupg2
@@ -88,6 +88,7 @@ COPY --from=builder /app/restyaboard-docker.zip /tmp/restyaboard.zip
 RUN unzip /tmp/restyaboard.zip -d ${ROOT_DIR} && \
     rm /tmp/restyaboard.zip && \
     chown -R www-data:www-data ${ROOT_DIR}
+RUN mv  ${ROOT_DIR}/api_explorer/ ${ROOT_DIR}/client/api_explorer/
 
 # install apps
 ADD docker-scripts/install_apps.sh /tmp/


### PR DESCRIPTION
## Description
Swagger documentation not available when installed using docker-compose issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
