### PR TITLE
Fixes #2791: Extra space adding before all the list name while adding the new board using workflow templates issue fixed.

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -1702,7 +1702,7 @@ function r_get($r_resource_cmd, $r_resource_vars, $r_resource_filters)
             $json = json_decode($data, true);
             $response[] = array(
                 'name' => $json['name'],
-                'value' => implode($json['lists'], ', ')
+                'value' => implode($json['lists'], ',')
             );
         }
         sort($response);


### PR DESCRIPTION
## Description
 Extra space adding before all the list name while adding the new board using workflow templates issue are fixed.

## Related Issue
No
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
