### PR TITLE
Fixes #2793: If we change the board visibility, it's not updated immediately. After refresh the page only, it's updated issue fixed.

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -2323,6 +2323,7 @@ App.BoardHeaderView = Backbone.View.extend({
             patch: true
         });
         var target = $(e.target);
+        target.parents('div.dropdown').find('.js-board-visibility:first').html('<i class="icon-lock"></i><span class="hidden-xs">' + i18next.t('Private') + '</span>');
         target.parents('div.dropdown').removeClass('open');
         return false;
     },
@@ -2349,6 +2350,7 @@ App.BoardHeaderView = Backbone.View.extend({
             patch: true
         });
         var target = $(e.target);
+        target.parents('div.dropdown').find('.js-board-visibility:first').html('<i class="icon-circle"></i><span class="hidden-xs">' + i18next.t('Public') + '</span>');
         target.parents('div.dropdown').removeClass('open');
         return false;
     },


### PR DESCRIPTION
## Description
If we change the board visibility, it's not updated immediately. After refresh the page only, it's updated issue are fixed.

## Related Issue
No
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
