### PR TITLE
Fixes #2825: after adding the new organization, in activities it showing "##ORGANIZATION_LINK##" instead of created organization link issue fixed.

### DIFF
--- a/client/js/templates/activity.jst.ejs
+++ b/client/js/templates/activity.jst.ejs
@@ -49,6 +49,10 @@
 					if(activity.attributes.comment.indexOf('##CARD_NAME##') != -1){
 						activity.attributes.comment = activity.attributes.comment.replace('##CARD_NAME##', (activity.attributes.card_name));
 					}
+					if(activity.attributes.comment.indexOf('##ORGANIZATION_LINK##') != -1){
+						activity.attributes.comment = activity.attributes.comment.replace('##ORGANIZATION_LINK##', organizationLink);
+					}
+					
 					if(activity.attributes.comment.indexOf('##LIST_NAME##') != -1){
 						activity.attributes.comment = activity.attributes.comment.replace('##LIST_NAME##', (activity.attributes.list_name));
 					}


### PR DESCRIPTION
## Description
After adding the new organization, in activities, it showing "##ORGANIZATION_LINK##" instead of created organization link issue fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
