### PR TITLE
fixes #2843 : Uncaught TypeError: Cannot read property '0' of undefined error thrown while adding "0" value in checklist items issue fixed.

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -5276,7 +5276,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
         $names = explode("\n", $r_post['name']);
         foreach ($names as $name) {
             $r_post['name'] = trim($name);
-            if (!empty($r_post['name'])) {
+            if (isset($r_post['name'])) {
                 $qry_val_arr = array(
                     $r_post['checklist_id']
                 );


### PR DESCRIPTION
## Description
Uncaught TypeError: Cannot read property '0' of undefined error thrown while adding "0" value in checklist items issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
