### PR TITLE
fixes #2844 : Uncaught TypeError: Cannot read property 'attributes' of undefined error thrown while clicking the "convert to card" in checklist items issue fixed.

### DIFF
--- a/client/js/common.js
+++ b/client/js/common.js
@@ -175,7 +175,7 @@ function CheckFieldExists(board, field_name, field_value, return_type, plugin_na
     if (!_.isUndefined(APPS) && APPS !== null) {
         if (!_.isUndefined(APPS.enabled_apps) && APPS.enabled_apps !== null) {
             if ($.inArray(plugin_name, APPS.enabled_apps) !== -1) {
-                if (!_.isUndefined(board.attributes.board_custom_fields) && !_.isEmpty(board.attributes.board_custom_fields)) {
+                if (!_.isUndefined(board) && !_.isEmpty(board) && !_.isUndefined(board.attributes) && !_.isEmpty(board.attributes) && !_.isUndefined(board.attributes.board_custom_fields) && !_.isEmpty(board.attributes.board_custom_fields)) {
                     board_custom_fields = JSON.parse(board.attributes.board_custom_fields);
                     if (!_.isUndefined(board_custom_fields[plugin_name])) {
                         r_gridview_configurations = board_custom_fields[plugin_name].split(',');

--- a/client/js/views/card_view.js
+++ b/client/js/views/card_view.js
@@ -612,7 +612,7 @@ App.CardView = Backbone.View.extend({
         var wrapper = $('.js-card-list-view-' + board_id + ' #js-card-' + this.model.id),
             items = wrapper.children(),
             r_listview_configure_positions, temp_dom = [];
-        if (!_.isEmpty(this.model.board.attributes.board_custom_fields) && !_.isUndefined(this.model.board.attributes.board_custom_fields)) {
+        if (!_.isUndefined(this.model.board) && !_.isEmpty(this.model.board) && !_.isUndefined(this.model.board.attributes.board_custom_fields) && !_.isEmpty(this.model.board.attributes.board_custom_fields)) {
             board_custom_fields = JSON.parse(this.model.board.attributes.board_custom_fields);
             if (!_.isUndefined(board_custom_fields.r_listview_configure_position) && !_.isUndefined(board_custom_fields.r_listview_configure_position)) {
                 r_listview_configure_positions = board_custom_fields.r_listview_configure_position.split(',');


### PR DESCRIPTION
## Description
Uncaught TypeError: Cannot read property 'attributes' of undefined error thrown while clicking the "convert to card" in checklist items issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
