### PR TITLE
Fixes #2859: Uncaught TypeError: Cannot read property 'position' of undefined error thrown, copy the list and then changing the position issue fixed

### DIFF
--- a/client/js/views/board_view.js
+++ b/client/js/views/board_view.js
@@ -1158,6 +1158,7 @@ App.BoardView = Backbone.View.extend({
                 list.board_users = self.model.board_users;
                 list.board_user_role_id = self.model.board_user_role_id;
                 if (!_.isUndefined(data.clone_list_id)) {
+                    $(view.render().el).attr('data-list_id', list.id);
                     $(view.render().el).insertAfter($(e.target).parents('.js-board-list'));
                 } else {
                     list.board = self.model;


### PR DESCRIPTION
## Description
Uncaught TypeError: Cannot read property 'position' of undefined error thrown, copy the list and then changing the position issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
