### PR TITLE
fixes #2870 : In card, check the "labels" spelling in label added activity and need the single space after the hyphen (-) issue fixed.

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -5203,7 +5203,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                 $deletenames = implode(",", array_diff($previous_cards_labels, $oldlabel));
                 $names = implode(",", $newlabel);
                 $names = preg_replace('/[ ,]+/', ', ', $names);
-                $comment = '##USER_NAME## removed the label(s) ' . ' - ' . $deletenames . ' and added the lables ' . '-' . $names . ' to the card ##CARD_LINK##';
+                $comment = '##USER_NAME## removed the label(s) ' . ' - ' . $deletenames . ' and added the label(s) ' . ' - ' . $names . ' to the card ##CARD_LINK##';
                 $type = 'update_card_label';
             }
         } else {


### PR DESCRIPTION
## Description
In card, check the "labels" spelling in label added activity and need the single space after the hyphen (-) issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
