### PR TITLE
Fixes #2877: Other user browser labels are not updated proper order. After refreshing the page only updated proper order issue fixed

### DIFF
--- a/server/php/libs/ActivityHandler.php
+++ b/server/php/libs/ActivityHandler.php
@@ -125,7 +125,7 @@ class ActivityHandler
             $obj_val_arr = array(
                 $obj['card_id']
             );
-            $s_result = pg_query_params($db_lnk, 'SELECT * FROM cards_labels_listing WHERE  card_id = $1', $obj_val_arr);
+            $s_result = pg_query_params($db_lnk, 'SELECT * FROM cards_labels_listing WHERE  card_id = $1 ORDER BY name ASC', $obj_val_arr);
             while ($row = pg_fetch_assoc($s_result)) {
                 $obj['labels'][] = $row;
             }


### PR DESCRIPTION
## Description
Other user browser labels are not updated proper order. After refreshing the page only updated proper order issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
