### PR TITLE
fixes #2972 : In empty list, when we sorting the list moved date , this console error thrown, Uncaught TypeError: Cannot read property 'get' of null issue fixed.

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -2269,7 +2269,7 @@ App.ListView = Backbone.View.extend({
                     });
                     return str;
                 } else if (sort_by === 'due_date') {
-                    if (item.get('due_date') !== null) {
+                    if (!_.isUndefined(item.get('due_date')) && item.get('due_date') !== null) {
                         var date = item.get('due_date').split(' ');
                         if (!_.isUndefined(date[1])) {
                             _date = date[0] + 'T' + date[1];
@@ -2280,7 +2280,7 @@ App.ListView = Backbone.View.extend({
                         return cards.sortDirection === 'desc' ? -sort_date.getTime() : sort_date.getTime();
                     }
                 } else if (sort_by === 'created_date') {
-                    if (item.get('created') !== null) {
+                    if (!_.isUndefined(item.get('created')) && item.get('created') !== null) {
                         var created_date = item.get('created').split(' ');
                         if (!_.isUndefined(created_date[1])) {
                             _date = created_date[0] + 'T' + created_date[1];
@@ -2291,7 +2291,7 @@ App.ListView = Backbone.View.extend({
                         return cards.sortDirection === 'desc' ? -sort_date.getTime() : sort_date.getTime();
                     }
                 } else if (sort_by === 'list_moved_date') {
-                    if (item.get('list_moved_date') !== null) {
+                    if (!_.isUndefined(item.get('list_moved_date')) && item.get('list_moved_date') !== null) {
                         var list_moved_date = item.get('list_moved_date').split(' ');
                         if (!_.isUndefined(list_moved_date[1])) {
                             _date = list_moved_date[0] + 'T' + list_moved_date[1];
@@ -2302,7 +2302,7 @@ App.ListView = Backbone.View.extend({
                         return cards.sortDirection === 'desc' ? -sort_date.getTime() : sort_date.getTime();
                     }
                 } else if (sort_by === 'start_date') {
-                    if (item.get('custom_fields') !== null) {
+                    if (!_.isUndefined(item.get('custom_fields')) && item.get('custom_fields') !== null) {
                         var inputArr = item.get('custom_fields');
                         var start_date_time = JSON.parse(inputArr);
                         if (!_.isUndefined(start_date_time.start_date)) {


### PR DESCRIPTION
## Description
In empty list, when we sorting the list moved date , this console error thrown, Uncaught TypeError: Cannot read property 'get' of null issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
