### PR TITLE
Fixes #2994: When we click the save button without giving the value in "description field, this console error came "Uncaught TypeError: Cannot read property 'replace' of null" issue fixed

### DIFF
--- a/client/js/templates/activity.jst.ejs
+++ b/client/js/templates/activity.jst.ejs
@@ -128,7 +128,7 @@
 											<%= makeLink(converter.makeHtml(activity.attributes.revisions.new_value.description), activity.attributes.board_id) %>
 										<% } else if(activity.attributes.description){ %>
 											<%= makeLink(converter.makeHtml(activity.attributes.description), activity.attributes.board_id) %>
-										<% } else { %>	
+										<% } else if(activity.attributes.card_description){ %>	
 											<%= makeLink(converter.makeHtml(activity.attributes.card_description), activity.attributes.board_id) %>
 										<% } %>				
 									</div>

--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -943,6 +943,7 @@ App.ModalCardView = Backbone.View.extend({
         e.preventDefault();
         var self = this;
         var validation = true;
+        var previous_description = self.model.attributes.description;
         var data = $(e.target).serializeObject();
         var edit_mode = $(e.target).closest('form').find('#inputCarddescriptions').data('edit_mode');
         if (edit_mode === 1 && $.trim(data.name) === '') {
@@ -994,6 +995,10 @@ App.ModalCardView = Backbone.View.extend({
                     self.$el.find('#cardDescriptionEditForm').addClass('hide');
                     validation = true;
                 }
+            } else if (previous_description === null || _.isEmpty(previous_description)) {
+                $('.error-msg').remove();
+                $('<div class="error-msg text-primary h6">Whitespace is not allowed</div>').insertAfter(self.$el.find('#inputCarddescriptions'));
+                validation = false;
             } else {
                 $('.error-msg').remove();
                 $('.js-show-card-desc').show();


### PR DESCRIPTION
## Description
When we click the save button without giving the value in "description field, this console error came "Uncaught TypeError: Cannot read property 'replace' of null" issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
