### PR TITLE
fixes #2969 : When we sorting the comments, some cards comments count has been removed issue fixed.

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1936,6 +1936,7 @@ App.ListView = Backbone.View.extend({
                         global_uuid[data.uuid] = options.temp_id;
                         card.set('id', data.uuid);
                     }
+                    card.set('comment_count', 0);
                     self.model.collection.board.cards.add(card);
                     self.model.cards.add(card);
                     _(function() {


### PR DESCRIPTION
## Description
When we sorting the comments, some cards comments count has been removed issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
