### PR TITLE
Fixes #3032 : When we go to the list view in empty board, console error thrown Uncaught TypeError: Cannot read property 'get' of null issue fixed.

### DIFF
--- a/client/js/templates/board_header.jst.ejs
+++ b/client/js/templates/board_header.jst.ejs
@@ -277,7 +277,7 @@
 									<% } %>
 									<% } %>
 									</li>
-									<% if (!_.isUndefined(APPS) && APPS !== null && !_.isUndefined(APPS.enabled_apps) && APPS.enabled_apps !== null && (($.inArray('r_gridview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_gridview_configure"})))) || ($.inArray('r_listview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_listview_configure"})))))) {%>
+									<% if (!_.isUndefined(APPS) && APPS !== null && !_.isUndefined(APPS.enabled_apps) && APPS.enabled_apps !== null && (($.inArray('r_gridview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_gridview_configure"})))) || ($.inArray('r_listview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_listview_configure"}))))) && !_.isUndefined(authuser.user) && (authuser.user.role_id == 1 || !_.isEmpty(board.acl_links.where({slug: "edit_board",board_user_role_id: parseInt(board.board_user_role_id)})))) {%>
 									<li><a href="#" class="nav-list-item nav-list-sub-item js-choose-columns"> <%- i18next.t('Choose Columns...') %></a></li>
 									<%}%>
 									<li class="js-background-change"></li>

--- a/client/js/templates/board_sidebar.jst.ejs
+++ b/client/js/templates/board_sidebar.jst.ejs
@@ -45,7 +45,7 @@
 	<% } %>
 	<% } %>
 	</li>
-	<% if (!_.isUndefined(APPS) && APPS !== null && !_.isUndefined(APPS.enabled_apps) && APPS.enabled_apps !== null && (($.inArray('r_gridview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_gridview_configure"})))) || ($.inArray('r_listview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_listview_configure"})))))) {%>
+	<% if (!_.isUndefined(APPS) && APPS !== null && !_.isUndefined(APPS.enabled_apps) && APPS.enabled_apps !== null && (($.inArray('r_gridview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_gridview_configure"})))) || ($.inArray('r_listview_configure',APPS.enabled_apps) !== -1 && (!_.isEmpty(role_links.where({slug: "r_listview_configure"}))))) && !_.isUndefined(authuser.user) && (authuser.user.role_id == 1 || !_.isEmpty(board.acl_links.where({slug: "edit_board",board_user_role_id: parseInt(board.board_user_role_id)})))) {%>
 	<li><a href="#" class="nav-list-item nav-list-sub-item js-choose-columns"> <%- i18next.t('Choose Columns...') %></a></li>
 	<% } %>  	
 	<li class="js-background-change"></li>


### PR DESCRIPTION
## Description
When we go to the list view in empty board, console error thrown Uncaught TypeError: Cannot read property 'get' of null issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
