### PR TITLE
Fixes #2985 : When we delete all the cards in archived items, all the cards are did not removed issue fixed.

### DIFF
--- a/client/js/views/archive_card_delete_confirm_view.js
+++ b/client/js/views/archive_card_delete_confirm_view.js
@@ -41,6 +41,12 @@ App.ArchiveCardDeleteConfirmView = Backbone.View.extend({
                         card.collection.remove(card);
                     }
                 });
+                var archived_cards = self.model.cards.where({
+                    is_archived: 1
+                });
+                self.model.cards.remove(archived_cards, {
+                    silent: true
+                });
                 self.flash('success', i18next.t('Cards deleted successfully.'));
                 $('.js-archived-items').trigger('click');
             }


### PR DESCRIPTION
## Description
When we delete all the cards in archived items, all the cards are did not removed issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
