### PR TITLE
Fixes #3020: While copy the list and then go to the boards page, card count is wrong in boards page issue fixed

### DIFF
--- a/client/js/views/board_simple_view.js
+++ b/client/js/views/board_simple_view.js
@@ -74,7 +74,7 @@ App.BoardSimpleView = Backbone.View.extend({
                 if (!list.attributes.is_archived) {
                     var _data = {};
                     _data.title = list.attributes.name;
-                    _data.value = list.attributes.card_count;
+                    _data.value = parseInt(list.attributes.card_count);
                     if (!_.isEmpty(list.attributes.color) && !_.isUndefined(list.attributes.color) && list.attributes.color !== null && list.attributes.color !== 'null' && list.attributes.color !== 'NULL') {
                         _data.color = list.attributes.color;
                     } else {


### PR DESCRIPTION
## Description
While copy the list and then go to the boards page, card count is wrong in boards page issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
