### PR TITLE
Fixes #3078: Drop box option has been displayed in card attachment section, while Dropbox app key is empty issue fixed

### DIFF
--- a/client/js/templates/modal_card_view.jst.ejs
+++ b/client/js/templates/modal_card_view.jst.ejs
@@ -701,7 +701,9 @@
 			   <li class="col-xs-12 clearfix text-center"> <div><span class="col-xs-10"><strong><%- i18next.t('Attach From...') %> </strong></span><a class="js-close-popover pull-right" href="#"><i class="icon-remove "></i></a></div> </li>
 				<li class="col-xs-12 divider"></li>
 				<li class="col-xs-12"><a href="#" title="<%- i18next.t('Computer') %>" class="js-attachment-computer-open row"><%- i18next.t('Computer') %></a></li>
+				<% if (!_.isUndefined(DROPBOX_APPKEY) && !_.isEmpty(DROPBOX_APPKEY)) { %>
 				<li class="col-xs-12"><a href="#" title="<%- i18next.t('Dropbox') %>" class="js-attachment-dropbox-open row"><%- i18next.t('Dropbox') %></a></li>
+				<% } %>
 				<li class="col-xs-12 divider"></li>
 				<li class="col-xs-12">
 				  <span class="col-xs-10 sr-only"><%- i18next.t('Attach a Link') %></span>


### PR DESCRIPTION
## Description
Drop box option has been displayed in card attachment section, while Dropbox app key is empty issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
