### PR TITLE
Fixes #3071: When we click the created and last activity time, page is redirecting to boards page issue fixed

### DIFF
--- a/client/js/templates/admin_board_view.jst.ejs
+++ b/client/js/templates/admin_board_view.jst.ejs
@@ -186,14 +186,14 @@
 	<%- board.attributes.archived_card_count%> 
 </td> 
 <td class="text-center">
-    <a href="#" class="js-no-action">
+    <a href="javascript:void(0);" class="js-no-action">
 		<% var created = parse_date(board.attributes.created, authuser, 'js-timeago1-admin-board-view-'+board.attributes.id); %>
 		<span class="js-timeago1-admin-board-view-<%- board.attributes.id %>"></span>
 	</a>
 	
 </td>
 <td class="text-center">
-    <a href="#" class="js-no-action">
+    <a href="javascript:void(0);" class="js-no-action">
 		<% var modified = parse_date(board.attributes.modified, authuser, 'js-timeago2-admin-board-view-'+board.attributes.id); %>
 		<span class="js-timeago2-admin-board-view-<%- board.attributes.id %>"></span>
 	</a>


### PR DESCRIPTION
## Description
When we click the created and last activity time, page is redirecting to boards page issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
