### PR TITLE
Fixes #2968: b.position is not a function error thrown when we create a list and then changing the list position issue fixed

### DIFF
--- a/client/js/models/list.js
+++ b/client/js/models/list.js
@@ -28,12 +28,12 @@ App.List = Backbone.Model.extend({
         var before = this.collection.get(beforeId);
         var after = this.collection.next(before);
         if (typeof after == 'undefined') {
-            afterPosition = before.position() + 2;
+            afterPosition = parseFloat(before.attributes.position) + 2;
         } else {
-            afterPosition = after.position();
+            afterPosition = parseFloat(after.attributes.position);
         }
-        var difference = (afterPosition - before.position()) / 2;
-        var newPosition = difference + before.position();
+        var difference = (afterPosition - parseFloat(before.attributes.position)) / 2;
+        var newPosition = difference + parseFloat(before.attributes.position);
         this.set({
             position: newPosition
         }, {
@@ -47,9 +47,9 @@ App.List = Backbone.Model.extend({
         if (typeof before == 'undefined') {
             beforePosition = 0.0;
         } else {
-            beforePosition = before.position();
+            beforePosition = parseFloat(before.attributes.position);
         }
-        var difference = (after.position() - beforePosition) / 2;
+        var difference = (parseFloat(after.attributes.position) - beforePosition) / 2;
         var newPosition = difference + beforePosition;
         this.set({
             position: newPosition


### PR DESCRIPTION
## Description
b.position is not a function error thrown when we create a list and then changing the list position issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
