### PR TITLE
Fixes #3107: If we unvoting the card and then sorting the cards, the voting count is wrong in the board's page (old voting count has been displayed) issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -1999,6 +1999,15 @@ App.ModalCardView = Backbone.View.extend({
         card_voter.set('id', voter_id);
         this.model.card_voters.remove(card_voter);
         this.model.list.collection.board.cards.get(self.model.id).card_voters.remove(card_voter);
+        if (!_.isUndefined(self.model.list.collection.board.cards.get(self.model.id).attributes.cards_voters) && self.model.list.collection.board.cards.get(self.model.id).attributes.cards_voters !== null) {
+            var card_voter_attr = self.model.list.collection.board.cards.get(self.model.id).attributes.cards_voters.filter(function(voter) {
+                return ((parseInt(voter.card_id) === parseInt(card_id)) && (parseInt(voter.user_id) === parseInt(authuser.user.id)));
+            });
+            if (card_voter_attr.length > 0) {
+                var card_voter_attr_index = self.model.list.collection.board.cards.get(self.model.id).attributes.cards_voters.indexOf(card_voter_attr[0]);
+                self.model.list.collection.board.cards.get(self.model.id).attributes.cards_voters.splice(card_voter_attr_index, 1);
+            }
+        }
         card_voter.url = api_url + 'boards/' + board_id + '/lists/' + list_id + '/cards/' + card_id + '/card_voters/' + voter_id + '.json';
         self.model.card_voters.remove(card_voter);
         var vote_count = self.model.attributes.card_voter_count;


### PR DESCRIPTION
## Description
If we unvoting the card and then sorting the cards, the voting count is wrong in the board's page (old voting count has been displayed) issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
