### PR TITLE
Fixes #3201 : When we copying the card without giving card name, console error thrown "default.cache.36e04bbc.js:80 Uncaught TypeError: Cannot read property 'is_archived' of undefined" issue fixed.

### DIFF
--- a/client/js/templates/modal_card_view.jst.ejs
+++ b/client/js/templates/modal_card_view.jst.ejs
@@ -352,7 +352,7 @@
 							  <form role="form" method="post" class="js-copy-card">
 								<div class="form-group">
 								  <label for="card-title"><%- i18next.t('Title') %></label>
-								  <input type="text" id="card-title" class="form-control" name="name" value="<%- card.attributes.name%>">
+								  <input type="text" id="card-title" class="form-control" name="name" value="<%- card.attributes.name%>" required>
 								</div>
 								<div class="js-show-copy-card-form-response-copy"> </div>
 								<div class="form-group clearfix">
@@ -749,7 +749,7 @@
 					<form role="form" method="post" class="js-copy-card">
 					<div class="form-group">
 						<label for="card-title"><%- i18next.t('Title') %></label>
-						<input type="text" id="card-title" class="form-control" name="name" value="<%- card.attributes.name%>">
+						<input type="text" id="card-title" class="form-control" name="name" value="<%- card.attributes.name%>" required>
 					</div>
 					<div class="js-show-copy-card-form-response"> </div>
 					<div class="form-group clearfix">


### PR DESCRIPTION
## Description
When we copying the card without giving card name, console error thrown "default.cache.36e04bbc.js:80 Uncaught TypeError: Cannot read property 'is_archived' of undefined" issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
