### PR TITLE
Fixes #2975: While try to move the card to other board with different sort by option using the move card option in the modal card page , the position field is not shown issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -4168,8 +4168,12 @@ App.ModalCardView = Backbone.View.extend({
                 }
             });
             self.$el.find('.js-change-position').html(content_list);
-            if (position_visiblity && self.$el.find('.js-position').parent().hasClass('hide')) {
+            if (position_visiblity) {
+              if (self.$el.find('.js-position').parent().hasClass('hide')) {
                 self.$el.find('.js-position').parent().removeClass('hide');
+              }
+            } else {
+                self.$el.find('.js-position').parent().addClass('hide');
             }
             self.$el.find('.js-position').html(content_position);
         }


### PR DESCRIPTION
## Description
While try to move the card to other board with different sort by option using the move card option in the modal card page , the position field is not shown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
