### PR TITLE
Fixes #3038: In copy card, unable to select the "attachment" field at very first time. It has been displayed as not clickable issue fixed

### DIFF
--- a/client/js/templates/copy_card.jst.ejs
+++ b/client/js/templates/copy_card.jst.ejs
@@ -4,7 +4,7 @@
 		<% if (card.attachments.length > 0) {%>
 			<div class="form-group">
 				<div class="checkbox">
-				<input id="Attachments-<%- card.id %>" class="hide" type="checkbox" name="keep_attachments" value="1" checked="checked">
+				<input id="Attachments-card-<%- card.id %>" class="hide" type="checkbox" name="keep_attachments" value="1" checked="checked">
 					<label for="Attachments-card-<%- card.id %>">
 					<%- i18next.t('Attachments') %>(<%- card.attachments.length %>)
 					</label>


### PR DESCRIPTION
## Description
 In copy card, unable to select the "attachment" field at very first time. It has been displayed as not clickable issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
