### PR TITLE
Fixes #3237: When moving the list from one board to another board, console error thrown "Uncaught TypeError: Cannot read property 'length' of undefined" issue fixed

### DIFF
--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -1759,7 +1759,7 @@ App.FooterView = Backbone.View.extend({
                                                 cache: false,
                                                 type: 'GET',
                                                 success: function(response) {
-                                                    if (response.data.length > 0) {
+                                                    if (!_.isUndefined(response.data) && response.data !== null && response.data.length > 0) {
                                                         _.each(response.data, function(card_data) {
                                                             var new_card = new App.Card();
                                                             var board_sort_by = (self.board.attributes.sort_by) ? self.board.attributes.sort_by : 'position';
@@ -1912,7 +1912,7 @@ App.FooterView = Backbone.View.extend({
                                                             }
                                                         });
                                                     }
-                                                    if (response.attachments.length > 0) {
+                                                    if (!_.isUndefined(response.attachments) && response.attachments !== null && response.attachments.length > 0) {
                                                         _.each(response.attachments, function(attachment) {
                                                             var new_card_attachment = new App.CardAttachment();
                                                             new_card_attachment.set(attachment);


### PR DESCRIPTION
## Description
When moving the list from one board to another board, console error thrown "Uncaught TypeError: Cannot read property 'length' of undefined" issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
