### PR TITLE
Fixes #3267: Start date is not showing on the board default sort option issue fixed

### DIFF
--- a/client/js/views/board_additional_setting_view.js
+++ b/client/js/views/board_additional_setting_view.js
@@ -78,8 +78,12 @@ App.BoardAdditionalSettingsView = Backbone.View.extend({
         var self = this;
         this.showTooltip();
         _(function() {
-            if (self.model !== null && !_.isUndefined(self.model) && !_.isEmpty(self.model) && !_.isUndefined(self.model.attributes.sort_by) && !_.isEmpty(self.model.attributes.sort_by)) {
-                $('body').trigger('boardAdditionalSettingsRendered', self.model.attributes.sort_by);
+            if (self.model !== null && !_.isUndefined(self.model) && !_.isEmpty(self.model)) {
+                var board_sort_by = 'position';
+                if (!_.isUndefined(self.model.attributes.sort_by) && !_.isEmpty(self.model.attributes.sort_by) && self.model.attributes.sort_by !== null) {
+                    board_sort_by = self.model.attributes.sort_by;
+                }
+                $('body').trigger('boardAdditionalSettingsRendered', board_sort_by);
             }
         }).defer();
         return this;


### PR DESCRIPTION
## Description
Start date is not showing on the board default sort option issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
