### PR TITLE
Fixes #2948 : When we move the card from one board to another board, other user browser moved card position is wrong issue fixed.

### DIFF
--- a/sql/upgrade-0.6.7-0.6.8.sql
+++ b/sql/upgrade-0.6.7-0.6.8.sql
@@ -297,7 +297,28 @@ SELECT board.id,
     board.music_content,
     board.music_name,
     board.sort_by,
-    board.sort_direction
+    board.sort_direction,
+    ( SELECT array_to_json(array_agg(row_to_json(cl.*))) AS array_to_json
+      FROM ( SELECT cards_listing.id,
+              cards_listing.created,
+              cards_listing.modified,
+              cards_listing.board_id,
+              cards_listing.list_id,
+              cards_listing.name,
+              cards_listing.due_date,
+              cards_listing."position",
+              cards_listing.list_moved_date,
+              ((cards_listing.is_archived)::boolean)::integer AS is_archived,
+              cards_listing.card_voter_count,
+              cards_listing.attachment_count,
+              cards_listing.comment_count,
+              cards_listing.checklist_item_count,
+              cards_listing.checklist_item_completed_count,
+              ((cards_listing.checklist_item_count)::integer - (cards_listing.checklist_item_completed_count)::integer) AS checklist_item_pending_count,
+              cards_listing.custom_fields
+              FROM public.cards_listing cards_listing
+            WHERE (cards_listing.board_id = board.id)
+            ORDER BY cards_listing."position") cl) AS cards
    FROM (boards board
      LEFT JOIN organizations org ON ((org.id = board.organization_id)))
   ORDER BY board.name;


### PR DESCRIPTION
## Description
When we move the card from one board to another board, other user browser moved card position is wrong issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
