### PR TITLE
Fixes #3279: While adding the card with card templates which contains  custom fields, the customfield design breaks in the preview issue fixed

### DIFF
--- a/client/js/templates/card_add.jst.ejs
+++ b/client/js/templates/card_add.jst.ejs
@@ -19,7 +19,7 @@
 		<ul class="list-unstyled list-inline text-muted clearfix"></ul>
 	</div>
 	<div class="row js-custom_fields-list hide">
-		<ul class="list-unstyled list-inline text-muted clearfix"></ul>
+		<ul class="list-unstyled list-inline text-muted clearfix txt-aligns"></ul>
 	</div>
 	<div class="row">     
 		<div class="pull-left js-list-<%- model.attributes.list_id %>-addCardForm">


### PR DESCRIPTION
## Description
While adding the card with card templates which contains  custom fields, the custom field design breaks in the preview issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
