### PR TITLE
Fixes #2531: After opening the card in the board, remaining cards are displayed as a clickable issue fixed

### DIFF
--- a/client/js/libs/jquery.dockmodal.js
+++ b/client/js/libs/jquery.dockmodal.js
@@ -254,7 +254,9 @@
                         $this.removeData('dockmodal');
                         $this.placeholder.replaceWith($this);
                         $dockModal.remove();
-                        $("." + dClass + "-overlay").hide();
+                        if ($('.dockmodal').length === 0 || !$('.dockmodal').hasClass('popped-out')) {
+                            $("." + dClass + "-overlay").hide();
+                        }
                         methods.refreshLayout();
 
                         // raise close event
@@ -340,7 +342,9 @@
                     "bottom": 42 + "px"
                 });
 
-                $("." + dClass + "-overlay").hide();
+                if (!$('.dockmodal').hasClass('popped-out')) {
+                    $("." + dClass + "-overlay").hide();
+                }
                 $dockModal.find(".action-minimize").attr("title", "Minimize");
                 $dockModal.find(".action-popout").attr("title", "Pop-out (ctrl+click)");
 

--- a/client/js/views/board_view.js
+++ b/client/js/views/board_view.js
@@ -850,6 +850,9 @@ App.BoardView = Backbone.View.extend({
                             }).showCardModal();
                         }
                     } else {
+                        if (i !== trigger_card_ids.length - 1) {
+                            card_view.attr('data-triggerModal', 'true');
+                        }
                         card_view.trigger('click');
                     }
                 }

--- a/client/js/views/card_view.js
+++ b/client/js/views/card_view.js
@@ -776,6 +776,10 @@ App.CardView = Backbone.View.extend({
         if (!_.isUndefined(e) && (e.ctrlKey || e.metaKey)) {
             initialState = 'modal';
         }
+        var triggerdock = this.$el.attr('data-triggerModal');
+        if (!_.isUndefined(triggerdock) && triggerdock !== null) {
+            initialState = 'docked';
+        }
         if (!_.isUndefined(this.model.id)) {
             var modalView = new App.ModalCardView({
                 model: this.model,


### PR DESCRIPTION
## Description
After opening the card in the board, remaining cards are displayed as a clickable issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
