### PR TITLE
Fixes #2948: When we move the card from one board to another board, other user browser moved card position is wrong issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -2311,7 +2311,7 @@ App.ModalCardView = Backbone.View.extend({
             });
             change_list_cards_collection = new App.CardCollection();
             change_list_cards_collection.add(change_list_cards);
-            if ((!_.isUndefined(board.attributes.sort_by) && board.attributes.sort_by !== null && board.attributes.sort_by === 'position') || (_.isUndefined(current_board.attributes.sort_by) || current_board.attributes.sort_by === null)) {
+            if ((!_.isUndefined(board.attributes.sort_by) && board.attributes.sort_by !== null && board.attributes.sort_by === 'position') || (_.isUndefined(board.attributes.sort_by) || board.attributes.sort_by === null)) {
                 i = 1;
                 change_list_cards_collection.each(function(card) {
                     if (!card.attributes.is_archived && _.isUndefined(change_next_card)) {


### PR DESCRIPTION
## Description
When we move the card from one board to another board, other user browser moved ard position is the wrong issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
