### PR TITLE
Fixes #2956: Once Move the card then close the card and we clicking back navigation, console error came issue fixed

### DIFF
--- a/client/js/views/board_view.js
+++ b/client/js/views/board_view.js
@@ -841,7 +841,7 @@ App.BoardView = Backbone.View.extend({
                         var card = self.model.cards.findWhere({
                             id: parseInt(trigger_card_ids[i])
                         });
-                        if (!_.isUndefined(card)) {
+                        if (!_.isUndefined(card) && card !== null && parseInt(card.board_id) === parseInt(self.model.id)) {
                             card.list = self.model.lists.findWhere({
                                 id: card.attributes.list_id
                             });


### PR DESCRIPTION
## Description
Once Move the card then close the card and we clicking back navigation, console error came issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
