### PR TITLE
Fixes #3324: While drag and drop cards between the list in the current board with default sort as position, card is triggered twice issue fixed

### DIFF
--- a/client/js/views/board_view.js
+++ b/client/js/views/board_view.js
@@ -614,7 +614,7 @@ App.BoardView = Backbone.View.extend({
     render: function() {
         touchPunchDelay = 100;
         var self = this;
-        sort_by = (this.model.attributes.sort_by) ? this.model.attributes.sort_direction : 'position';
+        sort_by = (this.model.attributes.sort_by) ? this.model.attributes.sort_by : 'position';
         sort_direction = (this.model.attributes.sort_direction) ? this.model.attributes.sort_direction : 'asc';
         $('body').addClass('modal-open');
         if (!_.isUndefined(App.boards) && !_.isUndefined(App.boards.sortField) && App.boards.sortField !== null && App.boards.sortField !== 'name') {

--- a/client/js/views/board_view.js
+++ b/client/js/views/board_view.js
@@ -614,7 +614,7 @@ App.BoardView = Backbone.View.extend({
     render: function() {
         touchPunchDelay = 100;
         var self = this;
-        sort_by = this.model.attributes.sort_by;
+        sort_by = (this.model.attributes.sort_direction) ? this.model.attributes.sort_direction : 'position';
         sort_direction = (this.model.attributes.sort_direction) ? this.model.attributes.sort_direction : 'asc';
         $('body').addClass('modal-open');
         if (!_.isUndefined(App.boards) && !_.isUndefined(App.boards.sortField) && App.boards.sortField !== null && App.boards.sortField !== 'name') {

--- a/client/js/views/board_view.js
+++ b/client/js/views/board_view.js
@@ -614,7 +614,7 @@ App.BoardView = Backbone.View.extend({
     render: function() {
         touchPunchDelay = 100;
         var self = this;
-        sort_by = (this.model.attributes.sort_direction) ? this.model.attributes.sort_direction : 'position';
+        sort_by = (this.model.attributes.sort_by) ? this.model.attributes.sort_direction : 'position';
         sort_direction = (this.model.attributes.sort_direction) ? this.model.attributes.sort_direction : 'asc';
         $('body').addClass('modal-open');
         if (!_.isUndefined(App.boards) && !_.isUndefined(App.boards.sortField) && App.boards.sortField !== null && App.boards.sortField !== 'name') {

--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -719,11 +719,7 @@ App.ListView = Backbone.View.extend({
             this.$el.remove();
             var i = 0;
             var current_position = 0;
-            if (sort_by !== null && sort_direction !== null) {
-                App.boards.get(board_id).lists.sortByColumn(sort_by, sort_direction);
-            } else {
-                App.boards.get(board_id).lists.sortByColumn('position', 'asc');
-            }
+            App.boards.get(board_id).lists.sortByColumn('position', 'asc');
             App.boards.get(board_id).lists.each(function(list) {
                 i++;
                 if (typeof next_list_id != 'undefined') {
@@ -1457,7 +1453,7 @@ App.ListView = Backbone.View.extend({
                 }
                 if (parseInt(e.attributes.is_archived) === 0) {
                     var card_exist = false;
-                    if ($('#js-card-' + e.attributes.id).length === 1) {
+                    if (sort_by !== 'position' && $('#js-card-' + e.attributes.id).length === 1) {
                         if ($('#js-card-modal-' + e.attributes.id).length === 1) {
                             card_exist = true;
                         }
@@ -1478,21 +1474,23 @@ App.ListView = Backbone.View.extend({
                         }
                         var bool = true;
                         i = 0;
-                        self.model.cards.each(function(card) {
-                            if (bool) {
-                                if (parseInt(card.attributes.id) === parseInt(e.attributes.id)) {
-                                    if (!_.isUndefined(self.model.cards.models[i - 1])) {
-                                        var prev_card_id = self.model.cards.models[i - 1].id;
-                                        $('#js-card-' + prev_card_id).after(view.render().el);
-                                        bool = false;
-                                    } else {
-                                        $('#js-card-listing-' + e.attributes.list_id).prepend(view.render().el);
-                                        bool = false;
+                        if ($('#js-card-' + e.attributes.id).length === 0) {
+                            self.model.cards.each(function(card) {
+                                if (bool) {
+                                    if (parseInt(card.attributes.id) === parseInt(e.attributes.id)) {
+                                        if (!_.isUndefined(self.model.cards.models[i - 1])) {
+                                            var prev_card_id = self.model.cards.models[i - 1].id;
+                                            $('#js-card-' + prev_card_id).after(view.render().el);
+                                            bool = false;
+                                        } else {
+                                            $('#js-card-listing-' + e.attributes.list_id).prepend(view.render().el);
+                                            bool = false;
+                                        }
                                     }
+                                    i++;
                                 }
-                                i++;
-                            }
-                        });
+                            });
+                        }
                     }
                     if (card_exist) {
                         $('#js-card-' + e.attributes.id).addClass('active');


### PR DESCRIPTION
## Description
While drag and drop cards between the list in the current board with default sort as position, card is triggered twice issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
