### PR TITLE
Fixes #2948: When we move the card from one board to another board, other user browser moved card position is wrong issue fixed

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -1085,7 +1085,7 @@ function r_get($r_resource_cmd, $r_resource_vars, $r_resource_filters)
                             }
                             $data = $obj;
                         }
-                        if (isset($_GET["type"]) && $_GET["type"] != "instant_card") {
+                        if (!isset($_GET["type"]) || (isset($_GET["type"]) && $_GET["type"] != "instant_card")) {
                             if (is_plugin_enabled('r_custom_fields')) {
                                 require_once PLUGIN_PATH . DS . 'CustomFields' . DS . 'functions.php';
                                 $data = customFieldAfterFetchBoard($r_resource_cmd, $r_resource_vars, $r_resource_filters, $data);


### PR DESCRIPTION
## Description
When we move the card from one board to another board, other user browser moved card position is wrong issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
