### PR TITLE
Fixes #3355: While clicking card link in the comment, modal card open and close the card, it will remove all the card id in the URL and change it into board/?/card issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -1446,6 +1446,7 @@ App.ModalCardView = Backbone.View.extend({
                 class_name = ' label label-warning';
                 title = i18next.t('This card is archived.');
             }
+            var close_modal_card = false;
             this.$el.dockmodal({
                 initialState: initialState,
                 height: 450,
@@ -1597,7 +1598,7 @@ App.ModalCardView = Backbone.View.extend({
                     }
                 },
                 close: function(event, dialog) {
-                    if (is_modalCard_close) {
+                    if (is_modalCard_close && !close_modal_card) {
                         $('#js-card-' + self.model.id).removeClass('active');
                         var current_param = Backbone.history.fragment;
                         if (current_param.indexOf('board/') != -1) {
@@ -1632,6 +1633,7 @@ App.ModalCardView = Backbone.View.extend({
                             event.remove();
                         }
                         self.model.unbind('change:list_id');
+                        close_modal_card = true;
                     }
                 }
             });


### PR DESCRIPTION
## Description
While clicking card link in the comment, modal card open and close the card, it will remove all the card id in the URL and change it into board/?/card issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
