### PR TITLE
Fixes #3363: After adding the values in admin panel settings page like calendar color,  it is not updated until page refresh issue fixed

### DIFF
--- a/client/js/views/setting_view.js
+++ b/client/js/views/setting_view.js
@@ -81,6 +81,11 @@ App.SettingView = Backbone.View.extend({
         settingModel.save(data, {
             success: function(model, response) {
                 if (!_.isEmpty(response.success)) {
+                    _.each(data, function(val, field) {
+                        if (field in window) {
+                            window[field] = val;
+                        }
+                    });
                     self.flash('success', i18next.t('Settings updated successfully.'));
                 } else {
                     self.flash('danger', i18next.t('Settings not updated properly.'));


### PR DESCRIPTION
## Description
After adding the values in admin panel settings page like calendar color,  it is not updated until page refresh issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
