### PR TITLE
Fixes #3375: After create the card, when we move the card from one list to another list this console error thrown "Uncaught TypeError: Cannot read property 'set' of undefined"  issue fixed

### DIFF
--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -2527,7 +2527,7 @@ App.FooterView = Backbone.View.extend({
                                         var new_card_list = parseInt(activity.attributes.revisions.new_value.list_id);
                                         var new_card_position = parseFloat(activity.attributes.revisions.new_value.position);
                                         var moved_card, oldList, newCardList, oldListCardCount, newListCardCount;
-                                        if (!_.isUndefined(card_revision.new_value.board_id) && card_revision.new_value.board_id !== null) {
+                                        if (!_.isUndefined(card_revision.new_value.board_id) && card_revision.new_value.board_id !== null && parseInt(card_revision.new_value.board_id) !== parseInt(card_revision.old_value.board_id)) {
                                             var old_card_board_id = parseInt(activity.attributes.revisions.old_value.board_id);
                                             var new_card_board_id = parseInt(activity.attributes.revisions.new_value.board_id);
                                             moved_card = App.boards.get(old_card_board_id).cards.get(parseInt(cardDetails.id));


### PR DESCRIPTION
## Description
After create the card, when we move the card from one list to another list this console error thrown "Uncaught TypeError: Cannot read property 'set' of undefined"  issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
