### PR TITLE
Fixes #3442: Missing the file upload option in the card attachment API call post method in API explorer issue fixed

### DIFF
--- a/api_explorer/swagger.json
+++ b/api_explorer/swagger.json
@@ -9379,6 +9379,13 @@
                         "required": true,
                         "type": "integer",
                         "format": "int64"
+                    },
+                    {
+                        "name": "attachment",
+                        "in": "formData",
+                        "description": "Upload File.",
+                        "required": false,
+                        "type": "file"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
## Description
Missing the file upload option in the card attachment API call post method in API explorer issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
