### PR TITLE
Fixes #3472: Missing the attachment link option in the card attachment API call post method in API explorer issue fixed

### DIFF
--- a/api_explorer/swagger.json
+++ b/api_explorer/swagger.json
@@ -9381,6 +9381,19 @@
                         "format": "int64"
                     },
                     {
+                        "name": "imageLink",
+                        "in": "body",
+                        "description": "Paste Link.",
+                        "required": false,
+                        "schema": {
+                            "properties": {
+                                "image_link": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    {
                         "name": "attachment",
                         "in": "formData",
                         "description": "Upload File.",


### PR DESCRIPTION
## Description
Missing the attachment link option in the card attachment API call post method in API explorer issue fixed

## Related Issue
NO

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
