### PR TITLE
Fixes #2975: While try to move the card to other board with different sort by option using the move card option in the modal card page , the position field is not shown issue fixed

### DIFF
--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -2412,6 +2412,10 @@ App.FooterView = Backbone.View.extend({
                                         App.boards.get(parseInt(activity.attributes.board_id)).set('is_closed', 1);
                                     } else if (activity.attributes.type === 'reopen_board') {
                                         App.boards.get(parseInt(activity.attributes.board_id)).set('is_closed', 0);
+                                    } else if (activity.attributes.type === 'update_sort_card') {
+                                        if (!_.isUndefined(activity.attributes.revisions) && !_.isEmpty(activity.attributes.revisions) && !_.isUndefined(App.boards.get(parseInt(activity.attributes.board_id))) && App.boards.get(parseInt(activity.attributes.board_id)) !== null) {
+                                            App.boards.get(parseInt(activity.attributes.board_id)).set(activity.attributes.revisions.new_value);
+                                        }
                                     } else if (activity.attributes.type === 'add_list') {
                                         var board_new_list = new App.List();
                                         board_new_list.set(activity.attributes.list);


### PR DESCRIPTION
## Description
While try to move the card to other board with different sort by option using the move card option in the modal card page , the position field is not shown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
