### PR TITLE
Fixes #3469: While clicking the grid view icon for the grid view in the board, the grid view is loaded again and the cards are rendered again issue fixed

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -2114,24 +2114,33 @@ App.BoardHeaderView = Backbone.View.extend({
      *
      */
     switchGridView: function(e) {
-        var self = this;
-        $('body').addClass('modal-open');
-        $('li.js-switch-view').removeClass('active');
-        $('#listview_table').attr("id", "switch-board-view");
-        e.preventDefault();
-        var current_param = Backbone.history.fragment;
-        var is_filter_cards = current_param.split('?');
-        if (is_filter_cards.length > 1) {
-            self.$el.find('.js-clear-filter-btn').trigger('click');
+        var currenturl = window.location;
+        var currentss = currenturl.hash;
+        var get_match_url = currentss.split("/");
+        var grid_view = false;
+        if (get_match_url.length === 3 && get_match_url['1'] === 'board') {
+            grid_view = true;
         }
-        app.navigate('#/board/' + this.model.id, {
-            trigger: false,
-            trigger_function: false,
-        });
-        $('#content').html(new App.BoardView({
-            model: this.model
-        }).el);
-        this.board_view_height();
+        if (!grid_view) {
+            var self = this;
+            $('body').addClass('modal-open');
+            $('li.js-switch-view').removeClass('active');
+            $('#listview_table').attr("id", "switch-board-view");
+            e.preventDefault();
+            var current_param = Backbone.history.fragment;
+            var is_filter_cards = current_param.split('?');
+            if (is_filter_cards.length > 1) {
+                self.$el.find('.js-clear-filter-btn').trigger('click');
+            }
+            app.navigate('#/board/' + this.model.id, {
+                trigger: false,
+                trigger_function: false,
+            });
+            $('#content').html(new App.BoardView({
+                model: this.model
+            }).el);
+            this.board_view_height();
+        }
     },
     /**
      * boardRename()


### PR DESCRIPTION
## Description
While clicking the grid view icon for the grid view in the board, the grid view is loaded again and the cards are rendered again issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
