### PR TITLE
Fixes #3458: While clicking the Show attachments option in the list and the board with no attachments, console error thrown issue fixed

### DIFF
--- a/client/js/views/attachment_view.js
+++ b/client/js/views/attachment_view.js
@@ -50,7 +50,11 @@ App.AttachmentView = Backbone.View.extend({
             attachment: this.model,
             board: this.board
         }));
-        this.$el.attr('class', 'clearfix col-md-4 col-sm-6 col-xs-12 navbar-btn js-card-attachment-' + this.board.id + '-' + this.model.id);
+        this.$el.attr('class', 'clearfix col-md-4 col-sm-6 col-xs-12 navbar-btn');
+        if (!_.isUndefined(this.model) && !_.isEmpty(this.model) && this.model !== null) {
+            this.$el.addClass('js-card-attachment-' + this.board.id + '-' + this.model.id);
+        }
+
         this.showTooltip();
         return this;
     },


### PR DESCRIPTION
## Description
While clicking the Show attachments option in the list and the board with no attachments, console error thrown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
