### PR TITLE
Fixes #3324: While drag and drop cards between the list in the current board with default sort as position, card is triggered twice issue fixed

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1475,7 +1475,6 @@ App.ListView = Backbone.View.extend({
                         if ($('#js-card-modal-' + e.attributes.id).length === 1) {
                             card_exist = true;
                         }
-                        $('#js-card-' + e.attributes.id).remove();
                     }
                     filtered_cards = self.model.board.cards.where({
                         is_archived: 0,
@@ -1497,10 +1496,18 @@ App.ListView = Backbone.View.extend({
                                 if (parseInt(card.attributes.id) === parseInt(e.attributes.id)) {
                                     if (!_.isUndefined(self.model.cards.models[i - 1])) {
                                         var prev_card_id = self.model.cards.models[i - 1].id;
-                                        $('#js-card-' + prev_card_id).after(view.render().el);
+                                        var next_card = $('#js-card-' + prev_card_id).after().data('card_id');
+                                        if (next_card !== parseInt(e.attributes.id)) {
+                                            $('#js-card-' + e.attributes.id).remove();
+                                            $('#js-card-' + prev_card_id).after(view.render().el);
+                                        }
                                         bool = false;
                                     } else {
-                                        $('#js-card-listing-' + e.attributes.list_id).prepend(view.render().el);
+                                        var first_card = $('#js-card-listing-' + e.attributes.list_id).find('.js-show-modal-card-view:first').data('card_id');
+                                        if (first_card !== parseInt(e.attributes.id)) {
+                                            $('#js-card-' + e.attributes.id).remove();
+                                            $('#js-card-listing-' + e.attributes.list_id).prepend(view.render().el);
+                                        }
                                         bool = false;
                                     }
                                 }


### PR DESCRIPTION
## Description
While drag and drop cards between the list in the current board with default sort as position, card is triggered twice issue fixed

## Related Issue
NO

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
