### PR TITLE
Fixes #3503: In the organizations listing page, the organizations should be ordered by name in descending direction by default issue fixed

### DIFF
--- a/client/js/templates/organizations_lists_header.jst.ejs
+++ b/client/js/templates/organizations_lists_header.jst.ejs
@@ -12,7 +12,7 @@
           <ul role="menu" class="dropdown-menu arrow">
             <li class="text-center text-muted"><strong><%- i18next.t('Sort') %></strong></li>
             <li class="divider"></li>
-            <li class="js-sort-by-organizations"><a title="<%- i18next.t('Name') %>" href="#" class="js-sort-by" data-field="name"><%- i18next.t('Name') %></a></li>
+            <li class="js-sort-by-organizations active"><a title="<%- i18next.t('Name') %>" href="#" class="js-sort-by" data-field="name"><i class="icon icon-arrow-down js-sort-up-organizations"></i><%- i18next.t('Name') %></a></li>
             <% _.each(user.models,function(organization,key) {
               if(key === 1) {
                 _.each(organization.attributes.organization_user_roles,function(organization_user_role) {

--- a/client/js/views/organizations_lists_header_view.js
+++ b/client/js/views/organizations_lists_header_view.js
@@ -29,7 +29,7 @@ App.OrganizationsListsHeaderView = Backbone.View.extend({
      * initialize default values and actions
      */
     initialize: function() {
-        this.sortField = 'id';
+        this.sortField = 'name';
         this.sortDirection = 'desc';
         if (!_.isUndefined(this.model) && this.model !== null) {
             this.model.showImage = this.showImage;
@@ -67,15 +67,10 @@ App.OrganizationsListsHeaderView = Backbone.View.extend({
         }
         $('.js-sort-down-organizations').remove();
         $('.js-sort-up-organizations').remove();
-        if (this.sortDirection === 'desc') {
-            if (this.sortField !== 'id') {
-                $(e.target).parent().addClass('active');
-                $(e.target).html('<i class="icon icon-arrow-up js-sort-up-organizations"></i>' + i18next.t($(e.target).text()));
-                this.sortDirection = 'asc';
-            } else {
-                $(e.target).parent().addClass('active');
-                $(e.target).html('<i class="icon icon-arrow-down js-sort-down-organizations"></i>' + i18next.t($(e.target).text()));
-            }
+        if (this.sortField === sortField) {
+            $(e.target).parent().addClass('active');
+            $(e.target).html('<i class="icon icon-arrow-up js-sort-up-organizations"></i>' + i18next.t($(e.target).text()));
+            this.sortDirection = 'asc';
         } else {
             $(e.target).parent().addClass('active');
             $(e.target).html('<i class="icon icon-arrow-down js-sort-down-organizations"></i>' + i18next.t($(e.target).text()));


### PR DESCRIPTION
## Description
In the organizations listing page, the organizations should be ordered by name in descending direction by default issue fixed

## Related Issue
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
