### PR TITLE
Fixes #3453: In the board page with large number lists, if we drag the list slightly, the other list is hidden issue fixed

### DIFF
--- a/client/css/custom.less
+++ b/client/css/custom.less
@@ -964,6 +964,7 @@ table.acl-link-list > tbody> tr {
 		}
 	}
 	.board-list-placeholder.list {
+		background: transparent;
 		border: 1px dashed #999;
 		height: 150px;
 	}


### PR DESCRIPTION
## Description
In the board page with large number lists, if we drag the list slightly, the other list is hidden issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
