### PR TITLE
Fixes #3559: While deleting the comment, other user is not updated and console error thrown issue fixed

### DIFF
--- a/client/js/templates/activity.jst.ejs
+++ b/client/js/templates/activity.jst.ejs
@@ -102,7 +102,7 @@
 						<% if(activity.attributes.type == 'add_comment') { 
 							var originalComment;
 							if (!_.isUndefined(activity.attributes.revisions) && !_.isEmpty(activity.attributes.revisions) && activity.attributes.revisions !== null) { 
-								originalComment = activity.attributes.revisions.old_value;
+								originalComment = activity.attributes.revisions.old_value.comment;
 							} else { 
 								originalComment = activity.attributes.comment;
 							}

--- a/client/js/templates/user_activity.jst.ejs
+++ b/client/js/templates/user_activity.jst.ejs
@@ -38,7 +38,7 @@
 						<% if(activity.attributes.type == 'add_comment' || activity.attributes.type == 'edit_comment') { %>	
 							<span><%= comment %></span>
 							<% if(activity.attributes.type == 'add_comment' && !_.isUndefined(activity.attributes.revisions) && !_.isEmpty(activity.attributes.revisions) && activity.attributes.revisions !== null) { 
-								activity.attributes.comment = activity.attributes.revisions.old_value;
+								activity.attributes.comment = activity.attributes.revisions.old_value.comment;
 							} %>
 							<% if(activity.attributes.type == 'add_comment') { %><div class="thumbnail media-body no-mar"><% } %>
 								<%= makeLink(converter.makeHtml((activity.attributes.comment)), activity.attributes.board_id) %>

--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -4729,7 +4729,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
             $r_post['board_id'] = $r_resource_vars['boards'];
         }
         $revision = '';
-        $revisions['old_value'] = $r_post['comment'];
+        $revisions['old_value']['comment'] = $r_post['comment'];
         $r_post['revisions'] = serialize($revisions);
         if (!empty($sql)) {
             $post = getbindValues($table_name, $r_post);
@@ -7746,7 +7746,11 @@ function r_delete($r_resource_cmd, $r_resource_vars, $r_resource_filters)
         if (!empty($revisions['revisions'])) {
             $revision = unserialize($revisions['revisions']);
             $revisions_del['comment'] = $comment;
-            $revisions_del['old_value'] = $revision['new_value']['comment'];
+            if(isset($revision['new_value']['comment'])) {
+                $revisions_del['old_value'] = $revision['new_value']['comment'];
+            } else {
+                $revisions_del['old_value'] = '';
+            }
             $revisions_del['new_value'] = '';
             $revisions_del = serialize($revisions_del);
         } else {


### PR DESCRIPTION
## Description
While deleting the comment, other user is not updated and console error thrown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
