### PR TITLE
Fixes #3561: While unselecting all the options in the filter cards after filtering the cards, console error thrown issue fixed

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -2468,8 +2468,7 @@ App.BoardHeaderView = Backbone.View.extend({
                             var options = {
                                 silent: true
                             };
-
-                            if (key === cards.length) {
+                            if (key === unfilteredCards.length) {
                                 options.silent = false;
                             }
                             card.set('is_filtered', false, options);


### PR DESCRIPTION
## Description
While unselecting all the options in the filter cards after filtering the cards, console error thrown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
