### PR TITLE
Fixes #3537: While clicking the list view icon for the list view in the board, the list view is loaded again and the cards are rendered again  issue fixed

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -868,7 +868,7 @@ App.BoardHeaderView = Backbone.View.extend({
         if (!_.isUndefined(get_match_url['3']) && get_match_url['3'].indexOf("list") !== -1) {
             list_view = true;
         }
-        if (e.originalEvent !== undefined || e.type === 'click') {
+        if ((e.originalEvent !== undefined || e.type === 'click') && $('#listview_table').length === 0) {
             trigger_list_view = true;
         } else if (e.changed !== undefined && list_view) {
             trigger_list_view = true;


### PR DESCRIPTION
## Description
While clicking the list view icon for the list view in the board, the list view is loaded again and the cards are rendered again  issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.