### PR TITLE
Fixes #3592 : After adding the labels in the modal card, if we try to change the order of the labels and save, labels order not changed issue fixed.

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -5269,6 +5269,9 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
                 $names = preg_replace('/[ ,]+/', ', ', $names);
                 $comment = '##USER_NAME## removed the label(s) ' . ' - ' . $deletenames . ' and added the label(s) ' . ' - ' . $names . ' to the card ##CARD_LINK##';
                 $type = 'update_card_label';
+            } else {
+                echo json_encode("Success");
+                break;
             }
         } else {
             $response['cards_labels'] = array();


### PR DESCRIPTION
## Description
After adding the labels in the modal card, if we try to change the order of the labels and save, labels order not changed issue fixed.

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
