### PR TITLE
Fixes #3603: If we click the view members board activity and load more button, header options gets jerking issue fixed

### DIFF
--- a/client/js/views/modal_user_activities_list_view.js
+++ b/client/js/views/modal_user_activities_list_view.js
@@ -78,7 +78,9 @@ App.ModalUserActivitiesListView = Backbone.View.extend({
                         return activity.id;
                     });
                     self.last_activity_id = last_activity.id;
-                    self.model.set('activity_count', response._metadata.total_records);
+                    self.model.set('activity_count', response._metadata.total_records, {
+                        silent: true
+                    });
                     self.renderActivitiesCollection(activities);
                 } else {
                     var view = new App.ActivityView({
@@ -127,7 +129,9 @@ App.ModalUserActivitiesListView = Backbone.View.extend({
                         return activity.id;
                     });
                     self.last_activity_id = last_activity.id;
-                    self.model.set('activity_count', response._metadata.total_records);
+                    self.model.set('activity_count', response._metadata.total_records, {
+                        silent: true
+                    });
                     self.renderActivitiesCollection(activities);
                 }
             }


### PR DESCRIPTION
## Description


## Related Issue
If we click the view members board activity and load more button, header options gets jerking issue fixed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.