### PR TITLE
Fixes #3552: When the mouse hover on the card at very first time, custom field values are did not displayed in calendar and gantt view issue fixed.

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -1435,6 +1435,13 @@ App.BoardHeaderView = Backbone.View.extend({
                                                 html: true,
                                                 placement: 'bottom'
                                             }).triggerHandler('mouseover');
+                                        }else{
+                                            $(target).tooltip({
+                                                selector: target,
+                                                title: card_customfield_value,
+                                                html: true,
+                                                placement: 'bottom'
+                                            }).triggerHandler('mouseover');
                                         }
                                     }
                                 }


### PR DESCRIPTION

## Description
When the mouse hovers on the card for the very first time, custom field values are did not displayed in the calendar and the Gantt view issue is fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
