### PR TITLE
Fixes #3539: While we add the card in first position of the list, unable to open the card issue fixed.

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1903,7 +1903,7 @@ App.ListView = Backbone.View.extend({
                     position: newPosition
                 });
                 data.position = newPosition;
-                next.before(view.render().el);
+                next.before().append(view.render().el);
             } else {
                 view_card.append(view.render().el);
             }


### PR DESCRIPTION

## Description
While we add the card in the first position of the list, unable to open the card issue is fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
