### PR TITLE
Fixes #3609: If we click the header in show attachments page, page is redirecting to boards page issue fixed

### DIFF
--- a/client/js/templates/modal_list_view.jst.ejs
+++ b/client/js/templates/modal_list_view.jst.ejs
@@ -3,7 +3,7 @@
 		  <div class="modal-content">
 			<div class="modal-header">
 			  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-			  <a href="#" title="<%- list.attributes.name %>" class="">
+			  <a href="javascript:void(0);" title="<%- list.attributes.name %>" class="">
 			  <h4 id="myModalLabel" class="modal-title htruncate"><strong><%- list.attributes.name %></strong></h4></a>
 			</div>			
 			<div class="modal-body clearfix">	


### PR DESCRIPTION
## Description
If we click the header in show attachments page, page is redirecting to boards page issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.