### PR TITLE
Fixes #3569: If we refresh the page in member view, page is redirected to task view and console error thrown issue fixed.

### DIFF
--- a/client/js/common.js
+++ b/client/js/common.js
@@ -72,6 +72,7 @@ $dc.ready(function() {
             if ($('#content #boards-view-' + $(this).data('board-viewtype')).length === 0) {
                 if (!_.isUndefined(App.current_board) && !_.isEmpty(App.current_board) && App.current_board !== null && !App.current_board.attributes.is_closed) {
                     $('#content .js-boards-view').remove('');
+                    view_type_tab = "task";
                     $('#content').html('<section id="boards-view-' + $(this).data('board-viewtype') + '" class="clearfix js-boards-view col-xs-12"></section>');
                 }
             }


### PR DESCRIPTION

## Description
If we refresh the page in member view, the page is redirected to a task view and console error thrown issue  are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
