### PR TITLE
Fixes #3545: Without selecting board visibility, if we click outside of the drop down, drop down should be closed issue fixed.

### DIFF
--- a/client/js/common.js
+++ b/client/js/common.js
@@ -78,6 +78,13 @@ $dc.ready(function() {
             }
         }
         return false;
+    }).on('click', 'body', function(e) {
+        if (!$('.js-open-dropdown .js-change-visibility').is(e.target) &&
+            $('.js-open-dropdown .js-change-visibility').has(e.target).length === 0 &&
+            $('.open').has(e.target).length === 0
+        ) {
+            $('.js-open-dropdown').removeClass('open');
+        }
     });
     if ((navigator.userAgent.toLowerCase().indexOf('android') > -1) && (navigator.userAgent.toLowerCase().indexOf('chrome') > -1)) {
         $('body').append('<div class="modal fade" id="add_home_modal" tabindex="-1" role="dialog" aria-hidden="false"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true" id="js-cssilize-close">x</span><span class="sr-only">Close</span></button><div class="media list-group-item-heading"><div class="media-body"><h4 class="modal-title" id="exampleModalLabel">Install this webapp to your phone</h4></div></div></div><div class="modal-body import-block"><ul><li>Add Restyaboard to homescreen.</li><li>Tap <i class="icon-ellipsis-vertical"></i>to bring up your browser menu and select \'Add to homescreen\' to pin the Restyaboard web app.</li></ul></div></div></div></div>');

--- a/client/js/views/board_add_view.js
+++ b/client/js/views/board_add_view.js
@@ -51,7 +51,6 @@ App.BoardAddView = Backbone.View.extend({
         var target = $(e.target);
         var parent = target.parents('form#BoardAddForm');
         $('.js-open-dropdown', parent).addClass('open');
-        $('.js-visibility-container', parent).html('');
         var visibility = $('#inputBoardAddVisibility', parent).val();
         $('.js-visibility-chooser', parent).html(new App.ShowAllVisibilityView({
             model: visibility


### PR DESCRIPTION
## Description
Without selecting board visibility, if we click outside of the drop-down, drop-down should be a closed issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
