### PR TITLE
Fixes #3618: If we changing the board name, board name is did not changed in "copy card, move card and boards page" in other user browser issue fixed

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -482,6 +482,7 @@ App.BoardHeaderView = Backbone.View.extend({
             var el = this.$el;
             if (el.find('.js-rename-board').length > 0) {
                 el.find('.js-rename-board').html('');
+                el.find('.js-rename-board').attr('title', self.model.attributes.name);
                 el.find('.js-rename-board').html('<strong>' + self.model.attributes.name + '</strong>');
             }
         }

--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -2463,6 +2463,11 @@ App.FooterView = Backbone.View.extend({
                                         }
                                     } else if (activity.attributes.type === 'close_board') {
                                         App.boards.get(parseInt(activity.attributes.board_id)).set('is_closed', 1);
+                                    } else if (activity.attributes.type === 'edit_board') {
+                                        var edit_board = App.boards.get(parseInt(activity.attributes.board_id));
+                                        if (!_.isUndefined(edit_board) && !_.isEmpty(edit_board) && edit_board !== null) {
+                                            edit_board.set('name', activity.attributes.revisions.new_value.name);
+                                        }
                                     } else if (activity.attributes.type === 'reopen_board') {
                                         App.boards.get(parseInt(activity.attributes.board_id)).set('is_closed', 0);
                                     } else if (activity.attributes.type === 'update_sort_card') {


### PR DESCRIPTION
## Description
If we changing the board name, board name is did not changed in "copy card, move card and boards page" in other user browser issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.