### PR TITLE
Fixes #3510: In the admin panel users listing page, the users should be ordered by name in descending direction by default issue fixed

### DIFF
--- a/client/js/views/admin_user_index_view.js
+++ b/client/js/views/admin_user_index_view.js
@@ -75,6 +75,7 @@ App.AdminUserIndexView = Backbone.View.extend({
             _this.users.setSortField(sort_direction['0'], sort_direction['1']);
         }
         if ((typeof _this.current_page === 'string' && _this.current_page.indexOf('&sort=') === -1) || _this.current_page === 1) {
+            _this.current_page = 1 + '&sort=username&direction=desc';
             _this.users.setSortField('username', 'desc');
         }
         var colspan = "15";


### PR DESCRIPTION
## Description
In the admin panel users listing page, the users should be ordered by name in descending direction by default issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.