### PR TITLE
Fixes #3619: Create the list and then set wip limit. Archive all the cards in the list, then send to board to card, wip limit count is wrong in current user browser issue fixed.

### DIFF
--- a/client/js/views/board_header_view.js
+++ b/client/js/views/board_header_view.js
@@ -2048,11 +2048,6 @@ App.BoardHeaderView = Backbone.View.extend({
             });
         }
         currentBoardList = App.current_board.lists.get(find_card.attributes.list_id);
-        if (!_.isUndefined(currentBoardList)) {
-            currentBoardList.set('card_count', currentBoardList.attributes.card_count + 1, {
-                silent: true
-            });
-        }
         if (!_.isUndefined(APPS) && APPS !== null && !_.isUndefined(APPS.enabled_apps) && APPS.enabled_apps !== null && $.inArray('r_agile_wip', APPS.enabled_apps) !== -1) {
             if (currentBoardList !== null && !_.isUndefined(currentBoardList) && !_.isEmpty(currentBoardList)) {
                 $('body').trigger('cardAddRendered', [currentBoardList.id, currentBoardList]);


### PR DESCRIPTION
## Description
Create the list and then set wip limit. Archive all the cards in the list, then send to board to card, wip limit count is wrong in current user browser issue are fixed.

## Related Issue
No

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
