### PR TITLE
Fixes #3705: a.connectedCallback is not a function console error thrown issue fixed

### DIFF
--- a/client/js/libs/snuggsi.min.js
+++ b/client/js/libs/snuggsi.min.js
@@ -107,7 +107,7 @@ var Template = function(t) {
 window.customElements = window.customElements || {}, customElements.define = function(t, e) {
     /\-/.test(t) && (customElements[t] = e) && [].slice.call(document.querySelectorAll(t)).map(customElements.upgrade)
 }, customElements.upgrade = function(t) {
-    Object.setPrototypeOf(t, customElements[t.localName].prototype), t.connectedCallback()
+    Object.setPrototypeOf(t, customElements[t.localName].prototype), 'undefined' !== t && t.connectedCallback()
 }, new MutationObserver(function(t) {
     for (var e = 0, n = t; e < n.length; e += 1)
         for (var o = 0, r = n[e].addedNodes; o < r.length; o += 1) {


### PR DESCRIPTION
## Description
a.connectedCallback is not a function console error thrown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.