### PR TITLE
Fixes #3752: In board show attachments, attachment count is wrong issue fixed

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1721,6 +1721,7 @@ App.ListView = Backbone.View.extend({
      *
      */
     showListModal: function(e) {
+        $('body').find('#modalListView').remove();
         var modalView = new App.ModalListView({
             model: this.model
         });

--- a/client/js/views/modal_board_view.js
+++ b/client/js/views/modal_board_view.js
@@ -82,6 +82,7 @@ App.ModalBoardView = Backbone.View.extend({
      * @return false
      */
     renderAttachmentsCollection: function() {
+        $('body').find('#modalListView').remove();
         var view_attachment = this.$('#js-list-attachments-list');
         view_attachment.html('');
         var attachments = this.model.attachments;


### PR DESCRIPTION
## Description
 In board show attachments, attachment count is wrong issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.