### PR TITLE
Fixes #3800: While loading the board with many labels, it takes long time to load issue fixed

### DIFF
--- a/client/js/views/board_view.js
+++ b/client/js/views/board_view.js
@@ -138,7 +138,9 @@ App.BoardView = Backbone.View.extend({
                         }).length <= 0) {
                         var new_label = new App.Label();
                         new_label.set(value);
-                        self.model.labels.unshift(new_label);
+                        self.model.labels.unshift(new_label, {
+                            silent: true
+                        });
                     }
                 });
             }


### PR DESCRIPTION
## Description
While loading the board with many labels, it takes long time to load issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
