### PR TITLE
Fixes #3570: If we edit the label and then go to the some other views and then come grid view, edited labels are did not updated properly  issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -662,6 +662,7 @@ App.ModalCardView = Backbone.View.extend({
                 silent: true
             });
         });
+        self.model.attributes.cards_labels = [];
         var card_label = new App.Label();
         card_label.set('is_offline', true);
         card_label.set('board_id', self.model.attributes.board_id);
@@ -692,6 +693,9 @@ App.ModalCardView = Backbone.View.extend({
                     labels = response.cards_labels;
                 }
                 if (labels.length > 0) {
+                    self.model.set('cards_labels', labels, {
+                        silent: true
+                    });
                     _.each(labels, function(label) {
                         var new_label = new App.Label();
                         new_label.set(label);


### PR DESCRIPTION
## Description
If we edit the label and then go to the some other views and then come grid view, edited labels are did not updated properly  issue fixed

## Related Issue
NO

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
