### PR TITLE
Fixes #3862: If we moving the card in last two list, scroll did not working properly issue fixed

### DIFF
--- a/client/js/views/list_view.js
+++ b/client/js/views/list_view.js
@@ -1304,6 +1304,9 @@ App.ListView = Backbone.View.extend({
                         }
                         var scrollLeft = 0;
                         var list_per_page = Math.floor($(window).width() / 270);
+                        if (App.sortable.previous_offset_horizontal === 0 && ui.offset.left > 0) {
+                            App.sortable.is_moving_right = true;
+                        }
                         if (App.sortable.previous_offset_horizontal !== 0 && App.sortable.previous_offset_horizontal != ui.offset.left) {
                             if (App.sortable.previous_offset_horizontal > ui.offset.left) {
                                 App.sortable.is_moving_right = false;


### PR DESCRIPTION
## Description
If we moving the card in last two list, scroll did not working properly issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
