### PR TITLE
Fixes #3891: In MyRestyaboards iOS app, Clicking the tooltip icon in admin roles page, page is redirecting to boards page issue fixed

### DIFF
--- a/client/js/templates/role_settings.jst.ejs
+++ b/client/js/templates/role_settings.jst.ejs
@@ -149,7 +149,7 @@
 												<input type="checkbox" class="cur" name="acl_link_id[<%- role.attributes.id %>][<%- acl_link.attributes.id %>]" value="<%- acl_link.attributes.id%>" <% if(!_.isEmpty(is_enabled)) { %> checked="checked" <% } %> id="acl_link_id_<%- role.attributes.id %>_<%- acl_link.attributes.id %>"/>
 												<label class="js-update-role" data-table="acl_links_roles" data-acl_link_id="<%- acl_link.attributes.id %>"  data-role_id="<%- role.attributes.id %>" for="acl_link_id_<%- role.attributes.id %>_<%- acl_link.attributes.id %>"></label>
 												<% if (acl_link.attributes.name === 'User activation') { %>
-													<a  data-placement="left" id="js-question-mark" href="#" data-toggle="tooltip" title="By clicking this, user can't login after registration without confirm the email"><i class="icon-question-sign" aria-hidden="true"></i></a>
+													<a  data-placement="left" id="js-question-mark" href="javascript:void(0);" data-toggle="tooltip" title="By clicking this, user can't login after registration without confirm the email"><i class="icon-question-sign" aria-hidden="true"></i></a>
 												<% } %>
 											</div>
 										</td>


### PR DESCRIPTION
## Description
In MyRestyaboards iOS app, Clicking the tooltip icon in admin roles page, page is redirecting to boards page issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
