### PR TITLE
Fixes #3957: While clicking the load more activities button in the all activities tab of the notification in the board page, the activities are not loaded issue fixed

### DIFF
--- a/client/js/views/footer_view.js
+++ b/client/js/views/footer_view.js
@@ -75,7 +75,7 @@ App.FooterView = Backbone.View.extend({
         },
         'click .js-board-load-more-all': function(e) {
             e.preventDefault();
-            this.loadMore('board', '0');
+            this.loadMore('user', '0');
             return false;
         },
         'click .js-all-load-more-all': function(e) {


### PR DESCRIPTION
## Description
While clicking the load more activities button in the all activities tab of the notification in the board page, the activities are not loaded issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
