### PR TITLE
Fixes #3965: After selecting "Select all" option in the List View configure app settings to show all fields, some custom fields are not shown issue fixed

### DIFF
--- a/client/js/views/switch_to_list_form_view.js
+++ b/client/js/views/switch_to_list_form_view.js
@@ -297,7 +297,7 @@ App.SwitchToListView = Backbone.View.extend({
             if (!_.isUndefined(board_custom_fields.r_listview_configure) && board_custom_fields.r_listview_configure !== null) {
                 r_listview_configure = board_custom_fields.r_listview_configure.split(',');
                 field_wrapper_items.each(function(label, key) {
-                    if (r_listview_configure.indexOf($(key).data('field-name')) === -1) {
+                    if (r_listview_configure.indexOf($(key).data('field-name')) === -1 && r_listview_configure.indexOf('selectall') === -1) {
                         if ($(key).data('field-name') === 'id') {
                             $(key).addClass('hide');
                         } else {


### PR DESCRIPTION
## Description
After selecting "Select all" option in the List View configure app settings to show all fields, some custom fields are not shown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
