### PR TITLE
Fixes #3967: While refreshing the board wiki page and board wiki manage page, clear filter button shown in the board header issue fixed

### DIFF
--- a/client/js/views/card_view.js
+++ b/client/js/views/card_view.js
@@ -331,10 +331,10 @@ App.CardView = Backbone.View.extend({
         }
         if (current_param[1]) {
             query_params = current_param[1].split(',');
-            query_params[0] = query_params[0].replace('filter=', '');
-            if (query_params.length > 0) {
+            if (query_params[0].indexOf('filter=') !== -1) {
                 $('.js-clear-filter-btn').removeClass('hide').addClass('show');
             }
+            query_params[0] = query_params[0].replace('filter=', '');
             $.each(query_params, function(index, value) {
                 if (value.indexOf('label:') > -1) {
                     total_filter += 1;


### PR DESCRIPTION
## Description
While refreshing the board wiki page and board wiki manage page, clear filter button shown in the board header issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
