### PR TITLE
Fixes #3985: If the board created user removed from Restyaboard, in the admin panel boards listing page, empty icon and broken link shown for the board created by the removed user issue fixed

### DIFF
--- a/client/js/templates/admin_board_view.jst.ejs
+++ b/client/js/templates/admin_board_view.jst.ejs
@@ -57,7 +57,11 @@
 </td> 
 <td>
 	<div class="clearfix">
-	   <a href="#/user/<%- board.attributes.user_id %>" class="small-user pull-left show" title="<%-board.attributes.full_name%> (<%-board.attributes.username%>)">
+		<% if(!board.attributes.full_name || !board.attributes.username){
+			board.attributes.full_name = i18next.t("[deleted account]");
+			board.attributes.username =  i18next.t("[deleted user]");
+	   }%>
+	   <a href="<% if (board.attributes.full_name !== '[deleted account]') { %>#/user/<%- board.attributes.user_id %><% }else{ %>javascript:void(0);<% } %>" class="small-user pull-left show" title="<%-board.attributes.full_name%> (<%-board.attributes.username%>)">
 	   		<% if(!_.isEmpty(board.attributes.profile_picture_path)){ 
 				var profile_picture_path = board.showImage('User', board.attributes.user_id, 'micro_thumb', true);
 			%>
@@ -66,7 +70,7 @@
 				<i class="avatar avatar-color-194 avatar-sm img-rounded"><%- board.attributes.initials%></i>
 			<% } %> 
 	   </a>
-	   <a href="#/user/<%- board.attributes.user_id %>" title="<%-board.attributes.full_name%> (<%-board.attributes.username%>)" class="col-xs-7 htruncate"><%-board.attributes.username%></a>
+	   <a href="<% if (board.attributes.full_name !== '[deleted account]') { %>#/user/<%- board.attributes.user_id %><% }else{ %>javascript:void(0);<% } %>" title="<%-board.attributes.full_name%> (<%-board.attributes.username%>)" class="col-xs-7 htruncate"><%-board.attributes.username%></a>
 	</div>
 </td>
 <td>


### PR DESCRIPTION
## Description
If the board created user removed from Restyaboard, in the admin panel boards listing page, empty icon and broken link shown for the board created by the removed user issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
