### PR TITLE
Fixes #3987: In the mobile view of Restyaboard, not able to change the board visibility in the admin panel boards listing page issue fixed

### DIFF
--- a/client/js/views/admin_board_view.js
+++ b/client/js/views/admin_board_view.js
@@ -199,11 +199,15 @@ App.AdminBoardView = Backbone.View.extend({
         var target = $(e.currentTarget);
         this.$('.js-back-to-board-visibility').addClass('hide');
         var visibility = this.model.attributes.board_visibility;
-        var insert = $('.js-visibility-list', target.next('.dropdown-menu'));
+        var insert = $('.js-visibility-list', target.parents('.js-visibility-list-dropdown').find('.dropdown-menu'));
         insert.nextAll().remove();
         $(new App.ShowBoardVisibilityView({
             model: visibility
         }).el).insertAfter(insert);
+        if (!target.parents('.js-visibility-list-dropdown').hasClass('open')) {
+            target.parents('.js-visibility-list-dropdown').addClass('open');
+        }
+        return false;
     },
     /**
      * backShowBoardVisibility()


### PR DESCRIPTION
## Description
In the mobile view of Restyaboard, not able to change the board visibility in the admin panel boards listing page issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
