### PR TITLE
Fixes #3989: While adding the board in the boards page, if we try to change the board visibility, the visibility drop down is not aligned correctly issue fixed

### DIFF
--- a/client/js/templates/board_add.jst.ejs
+++ b/client/js/templates/board_add.jst.ejs
@@ -51,7 +51,7 @@
 						</button>
 					</div>
 				</span>
-				<div class="js-visibility-chooser dropdown-menu"></div>
+				<div class="js-visibility-chooser dropdown-menu pull-right"></div>
 			</div>
 		<% } %>
 		<div id="js-board-add-group"></div>


### PR DESCRIPTION
## Description
While adding the board in the boards page, if we try to change the board visibility, the visibility drop down is not aligned correctly issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
