### PR TITLE
Fixes #3975: While adding card in the list of the board, if we try to add label with selected colour, label is not shown in the preview with it's colour issue fixed

### DIFF
--- a/client/js/views/card_view.js
+++ b/client/js/views/card_view.js
@@ -942,7 +942,7 @@ App.CardView = Backbone.View.extend({
                 labels.push(e.choice.text);
                 self.$el.find('.js-card-add-labels').val(labels.join(','));
                 var labelColor;
-                if (!_.isEmpty(tagColors) && !_.isUndefined(tagColors[e.choice.text]) && tagColors[e.choice.text] !== null) {
+                if (!_.isEmpty(tagColors) && !_.isUndefined(tagColors[e.choice.text]) && tagColors[e.choice.text] !== null && !_.isEmpty(tagColors[e.choice.text])) {
                     labelColor = tagColors[e.choice.text];
                 } else {
                     labelColor = '#' + calcMD5("" + e.choice.text).slice(0, 6).substring(0, 6);


### PR DESCRIPTION
## Description
While adding card in the list of the board, if we try to add label with selected colour, label is not shown in the preview with it's colour issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
