### PR TITLE
Fixes #3996: The board names in the boards drpdown of the each organization in the organizations page is not aligned correctly issue fixed

### DIFF
--- a/client/js/templates/organizations_list_view.jst.ejs
+++ b/client/js/templates/organizations_list_view.jst.ejs
@@ -47,7 +47,13 @@ if (!_.isUndefined(authuser.user)) {
 				<% if(organization.attributes.organizations_user_count != 0){ %>
 					<ul class="dropdown-menu arrow arrow-left  text-left" role="boards">
 						<% _.each(organization.attributes.organizations_users, function(organizations_user){%>
-							<li><a href="#/user/<%-organizations_user.user_id%>"><%-organizations_user.username%></a></li>
+							<li>
+								<a href="#/user/<%-organizations_user.user_id%>" class="clearfix">
+									<span class="details navbar-btn">
+										<span class="htruncate btn-block navbar-btn"><%-organizations_user.username%></span>
+									</span>
+								</a>
+							</li>
 						<%})%>
 					</ul>
 				<%}%>
@@ -81,10 +87,10 @@ if (!_.isUndefined(authuser.user)) {
 								}
 							%>
 								<li>
-									<a href="#/board/<%-board.id%>">
-										<span style="<%= style %>" class="preview-thumbnail"></span>
+									<a href="#/board/<%-board.id%>" class="clearfix">
+										<span style="<%= style %>" class="mt5 preview-thumbnail"></span>
 										<span class="details navbar-btn">
-											<span title="<%- board.name %>" class="board-list-item-name navbar-btn"><%- board.name %></span>
+											<span title="<%- board.name %>" class="board-list-item-name htruncate btn-block navbar-btn"><%- board.name %></span>
 										</span> 
 									</a>
 								</li>


### PR DESCRIPTION
## Description
The board names in the boards drpdown of the each organization in the organizations page is not aligned correctly issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
