### PR TITLE
Fixes #4002: Wrong content and option in the cards API call get method in API explorer issue fixed

### DIFF
--- a/api_explorer/swagger.json
+++ b/api_explorer/swagger.json
@@ -5511,8 +5511,8 @@
                 "tags": [
                     "cards"
                 ],
-                "summary": "Archived card send back to board",
-                "description": "Archived card send back to board",
+                "summary": "View list cards of the board",
+                "description": "View list cards of the board",
                 "produces": [
                     "application/json"
                 ],
@@ -5542,19 +5542,6 @@
                         "required": true,
                         "type": "integer",
                         "format": "int64"
-                    },
-                    {
-                        "name": "body",
-                        "in": "body",
-                        "description": "Created comment object",
-                        "required": true,
-                        "schema": {
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
## Description
Wrong content and option in the cards API call get method in API explorer issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
