### PR TITLE
feat(docker, server): optimize docker db usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,15 +86,15 @@ RUN cp restyaboard.conf ${CONF_FILE} && \
 
 # entrypoint
 COPY docker-scripts/docker-entrypoint.sh /
+COPY docker-scripts/init-db.sh /
 
 # Default values. Can be changed during container start.
 ENV POSTGRES_HOST=postgres \
     POSTGRES_PORT=5432 \
-    POSTGRES_USER=admin \
-    POSTGRES_PASSWORD=admin \
-    POSTGRES_DB=restyaboard
+    RESTYA_DB=restyaboard
 
 RUN chmod +x /docker-entrypoint.sh
+RUN chmod +x /init-db.sh
 RUN chmod +x server/php/shell/main.sh
 
 # TODO root user should be avoided but required for now

--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ To upgrade, overwrite application files and apply respective DB script:
 
 * [Restya Google Group](https://groups.google.com/d/forum/restya)
 
+
+### Docker configuration
+
+In the container you can set following variables:
+
+| Variable            | Description                                                                  | Default       |
+| ------------------- | ---------------------------------------------------------------------------- | ------------- |
+| POSTGRES_HOST       | The host address of postgres.                                                | `postgres`    |
+| POSTGRES_PORT       | The port of the postgres host.                                               | `5432`        |
+| POSTGRES_ADMIN_USER | An admin user in postgres. (Needed for creating restya user and extensions.) |               |
+| POSTGRES_ADMIN_PASS | The password of the admin postgres user.                                     |               |
+| RESTYA_DB_USERNAME  | The desired restya db user which has access to the restya database.          |               |
+| RESTYA_DB_USERPASS  | The restya db user password.                                                 |               |
+| RESTYA_DB           | Name of the database for restya.                                             | `restyaboard` |
+| SMTP_SERVER         | Address of the SMTP server.                                                  | `smtp_relay`  |
+| SMTP_PORT           | Port of the SMTP server.                                                     | `587`         |
+| TZ                  | Used timezone inside container.                                              | `Etc/UTC`     |
+
+
+#### Database
+
+The docker container creates necessary restyaboard user and relations in postgres during startup.
+Therefore it checks if the `RESTYA_DB` database already exists.
+If it exists it skips the init step for database.
+
+This means if you setup the database on your own you have also to make sure that all relations and users will be added.
+
 ------------
 
 ### Current Status / Plans / Roadmap

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,12 +5,15 @@ services:
       - /var/opt/restya/media:/usr/share/nginx/html/media
     environment:
       - POSTGRES_HOST=postgres
-      - POSTGRES_USER=admin
-      - POSTGRES_PASSWORD=admin
-      - POSTGRES_DB=restyaboard
+      - POSTGRES_PORT=5432
+      - POSTGRES_ADMIN_USER=postgres
+      - POSTGRES_ADMIN_PASS=admin
+      - RESTYA_DB_USERNAME=restya
+      - RESTYA_DB_USERPASS=restya
+      #- RESTYA_DB=restyaboard
       #- SMTP_SERVER=smtp_relay
       #- SMTP_PORT=587
-      - TZ=Etc/UTC
+      #- TZ=Etc/UTC
     depends_on:
       - postgres
     restart: always
@@ -26,8 +29,6 @@ services:
   postgres:
     image: postgres:9-alpine
     environment:
-      - POSTGRES_HOST=postgres
-      - POSTGRES_USER=admin
+      - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=admin
-      - POSTGRES_DB=restyaboard
     restart: always

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
       - ALLOW_EMPTY_SENDER_DOMAINS=true
 
   postgres:
-    image: postgres:9-alpine
+    image: postgres:12-alpine
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 services:
   restyaboard:
     build: .
@@ -7,12 +7,14 @@ services:
     environment:
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
-      - POSTGRES_USER=admin
-      - POSTGRES_PASSWORD=admin
-      - POSTGRES_DB=restyaboard
+      - POSTGRES_ADMIN_USER=postgres
+      - POSTGRES_ADMIN_PASS=admin
+      - RESTYA_DB_USERNAME=restya
+      - RESTYA_DB_USERPASS=restya
+      - RESTYA_DB=restyaboard
       #- SMTP_SERVER=smtp_relay
       #- SMTP_PORT=587
-      - TZ=Etc/UTC
+      #- TZ=Etc/UTC
     depends_on:
       - postgres
     restart: always
@@ -35,8 +37,6 @@ services:
   postgres:
     image: postgres:9-alpine
     environment:
-      - POSTGRES_HOST=postgres
-      - POSTGRES_USER=admin
+      - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=admin
-      - POSTGRES_DB=restyaboard
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "1080:80"
 
   postgres:
-    image: postgres:9-alpine
+    image: postgres:12-alpine
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=admin

--- a/docker-scripts/docker-entrypoint.sh
+++ b/docker-scripts/docker-entrypoint.sh
@@ -1,15 +1,23 @@
 #!/bin/sh
-set -e
-
 if [ "$1" = 'start' ]; then
+
+  echo "Starting restya ..."
+
+  [[ -z "${POSTGRES_HOST:+x}" ]] && echo "Variable POSTGRES_HOST is not set!" && exit 1
+  [[ -z "${POSTGRES_PORT:+x}" ]] && echo "Variable POSTGRES_PORT is not set!" && exit 1
+  [[ -z "${POSTGRES_ADMIN_USER:+x}" ]] && echo "Variable POSTGRES_ADMIN_USER is not set!" && exit 1
+  [[ -z "${POSTGRES_ADMIN_PASS:+x}" ]] && echo "Variable POSTGRES_ADMIN_PASS is not set!" && exit 1
+  [[ -z "${RESTYA_DB_USERNAME:+x}" ]] && echo "Variable is not set!" && exit 1
+  [[ -z "${RESTYA_DB_USERPASS:+x}" ]] && echo "Variable is not set!" && exit 1
+  [[ -z "${RESTYA_DB:+x}" ]] && echo "Variable is not set!" && exit 1
 
   # config
   sed -i \
       -e "s/^.*'R_DB_HOST'.*$/define('R_DB_HOST', '${POSTGRES_HOST}');/g" \
       -e "s/^.*'R_DB_PORT'.*$/define('R_DB_PORT', '${POSTGRES_PORT}');/g" \
-      -e "s/^.*'R_DB_USER'.*$/define('R_DB_USER', '${POSTGRES_USER}');/g" \
-      -e "s/^.*'R_DB_PASSWORD'.*$/define('R_DB_PASSWORD', '${POSTGRES_PASSWORD}');/g" \
-      -e "s/^.*'R_DB_NAME'.*$/define('R_DB_NAME', '${POSTGRES_DB}');/g" \
+      -e "s/^.*'R_DB_USER'.*$/define('R_DB_USER', '${RESTYA_DB_USERNAME}');/g" \
+      -e "s/^.*'R_DB_PASSWORD'.*$/define('R_DB_PASSWORD', '${RESTYA_DB_USERPASS}');/g" \
+      -e "s/^.*'R_DB_NAME'.*$/define('R_DB_NAME', '${RESTYA_DB}');/g" \
       ${ROOT_DIR}/server/php/config.inc.php
 
   # Relay SMTP server should be configured in another service
@@ -28,26 +36,14 @@ php_admin_value[error_log] = /var/log/php7/$pool.error.log
 php_admin_flag[log_errors] = on
 EOF
 
-  # init db
-  export PGHOST=${POSTGRES_HOST}
-  export PGPORT=${POSTGRES_PORT}
-  export PGUSER=${POSTGRES_USER}
-  export PGPASSWORD=${POSTGRES_PASSWORD}
-  export PGDATABASE=${POSTGRES_DB}
-  
-  set +e
-  while :
-  do
-    psql -c "\q"
-    if [ "$?" = 0 ]; then
-      break
-    fi
-    sleep 1
-  done
-  if [ "$(psql -c '\d')" = "" ]; then
-    psql -f "${ROOT_DIR}/sql/restyaboard_with_empty_data.sql"
+  # Init DB
+  sh /init-db.sh
+
+  if [ "$?" != 0 ]
+  then
+      echo "Failed to initialize DB for restyaboard."
+      exit 1
   fi
-  set -e
 
   # cron shell
   echo "*/5 * * * * ${ROOT_DIR}/server/php/shell/main.sh" >> /var/spool/cron/crontabs/root

--- a/docker-scripts/docker-entrypoint.sh
+++ b/docker-scripts/docker-entrypoint.sh
@@ -7,9 +7,9 @@ if [ "$1" = 'start' ]; then
   [[ -z "${POSTGRES_PORT:+x}" ]] && echo "Variable POSTGRES_PORT is not set!" && exit 1
   [[ -z "${POSTGRES_ADMIN_USER:+x}" ]] && echo "Variable POSTGRES_ADMIN_USER is not set!" && exit 1
   [[ -z "${POSTGRES_ADMIN_PASS:+x}" ]] && echo "Variable POSTGRES_ADMIN_PASS is not set!" && exit 1
-  [[ -z "${RESTYA_DB_USERNAME:+x}" ]] && echo "Variable is not set!" && exit 1
-  [[ -z "${RESTYA_DB_USERPASS:+x}" ]] && echo "Variable is not set!" && exit 1
-  [[ -z "${RESTYA_DB:+x}" ]] && echo "Variable is not set!" && exit 1
+  [[ -z "${RESTYA_DB_USERNAME:+x}" ]] && echo "Variable RESTYA_DB_USERNAME is not set!" && exit 1
+  [[ -z "${RESTYA_DB_USERPASS:+x}" ]] && echo "Variable RESTYA_DB_USERPASS is not set!" && exit 1
+  [[ -z "${RESTYA_DB:+x}" ]] && echo "Variable RESTYA_DB is not set!" && exit 1
 
   # config
   sed -i \

--- a/docker-scripts/init-db.sh
+++ b/docker-scripts/init-db.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+export PGHOST=${POSTGRES_HOST}
+export PGPORT=${POSTGRES_PORT}
+export PGUSER=${POSTGRES_ADMIN_USER}
+export PGPASSWORD=${POSTGRES_ADMIN_PASS}
+
+DB_RESTYA_USER=${RESTYA_DB_USERNAME}
+DB_RESTYA_PASS=${RESTYA_DB_USERPASS}
+DB_RESTYA=${RESTYA_DB}
+
+INIT_SQL_FILE="$ROOT_DIR/sql/restyaboard_with_empty_data.sql"
+
+while :
+do
+    echo "Trying to connect to postgres ..."
+    pg_isready
+    if [ "$?" = 0 ]; then
+        echo "Connection established!"
+        break
+    fi
+    sleep 1s
+done
+
+if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$RESTYA_DB'" )" = '1' ]; then
+    echo "Postgres database for restya already exists. (Database name: $RESTYA_DB). Skipping DB init."
+    return 0
+fi
+
+echo "Creating PostgreSQL user and database..."
+
+psql -c "DROP USER IF EXISTS ${DB_RESTYA_USER};CREATE USER ${DB_RESTYA_USER} WITH ENCRYPTED PASSWORD '${DB_RESTYA_PASS}'"
+error_code=$?
+if [ ${error_code} != 0 ]
+then
+    echo "PostgreSQL user creation failed with error code ${error_code} (PostgreSQL user creation failed with error code 35)"
+    return 35
+fi
+
+psql -c "CREATE DATABASE ${RESTYA_DB} OWNER ${DB_RESTYA_USER} ENCODING 'UTF8' TEMPLATE template0"
+error_code=$?
+if [ ${error_code} != 0 ]
+then
+    echo "PostgreSQL database creation failed with error code ${error_code} (PostgreSQL database creation failed with error code 36)"
+    return 36
+fi
+
+psql -c "CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;"
+error_code=$?
+if [ ${error_code} != 0 ]
+then
+    echo "PostgreSQL extension creation failed with error code ${error_code} (PostgreSQL extension creation failed with error code 37)"
+    return 37
+fi
+
+psql -c "COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';"
+error_code=$?
+if [ ${error_code} != 0 ];
+then
+    echo "PostgreSQL extension comment failed with error code ${error_code}."
+    return 38
+fi
+
+if [ -f "$INIT_SQL_FILE" ]
+then
+    echo "Importing empty SQL... (pipe output to /tmp/restya_initdb.log)"
+    PGPASSWORD=$DB_RESTYA_PASS psql -d ${DB_RESTYA} -f "$ROOT_DIR/sql/restyaboard_with_empty_data.sql" -U ${DB_RESTYA_USER} > /tmp/restya_initdb.log
+    
+    if [ ${error_code} != 0 ]
+    then
+        echo "PostgreSQL Empty SQL importing failed with error code ${error_code} (PostgreSQL Empty SQL importing failed with error code 39)"
+        return 39
+    fi
+
+    echo "Succesfully imported initial data."
+else
+    echo "Init SQL file does not exists. Maybe not mounted into correct place? Should be '$INIT_SQL_FILE'."
+    return 40
+fi

--- a/server/php/shell/main.php
+++ b/server/php/shell/main.php
@@ -16,7 +16,7 @@ $app_path = dirname(dirname(__FILE__));
 require_once $app_path . '/config.inc.php';
 require_once $app_path . '/libs/core.php';
 require_once $app_path . '/libs/vendors/finediff.php';
-$files = glob(APP_PATH . DS . 'server/php/shell/*.php', GLOB_BRACE);
+$files = glob(APP_PATH . DS . 'server/php/shell/*.php');
 if (!empty($files)) {
     foreach ($files as $file) {
         if ($file !== APP_PATH . DS . 'server/php/shell/main.php') {
@@ -24,7 +24,7 @@ if (!empty($files)) {
         }
     }
 }
-$pluginfiles = glob(PLUGIN_PATH . DS . '*' . DS . 'shell' . DS . '*.php', GLOB_BRACE);
+$pluginfiles = glob(PLUGIN_PATH . DS . '*' . DS . 'shell' . DS . '*.php');
 if (!empty($pluginfiles)) {
     foreach ($pluginfiles as $pluginfile) {
         include_once $pluginfile;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Optimize DB usage with docker setup.
And added documentation of variables used in docker.

## Description
<!--- Describe your changes in detail -->

- Now the docker setup separates between postgres admin user and restya user for the matching restya DB.
Follows the same setup as in `restyaboard.sh`.
- Added documentation to `README.md`
- Separate DB script
  - Only executes init db stuff if the used restya DB is not created already. Otherwise it skips the init steps.

- Remove traces of `GLOB_BRACE` in `main.php`


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related #4018 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Keep improving docker solution :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
