### PR TITLE
Fixes #4015: Missing the board delete API call in the API explorer issue fixed

### DIFF
--- a/api_explorer/swagger.json
+++ b/api_explorer/swagger.json
@@ -2809,6 +2809,54 @@
                         "description": "Page not found"
                     }
                 }
+            },
+            "delete": {
+                "tags": [
+                    "boards"
+                ],
+                "summary": "Deletes the board",
+                "description": "",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "query",
+                        "description": "OAuth token",
+                        "required": true,
+                        "type": "string",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "boardId",
+                        "in": "path",
+                        "description": "ID of Board that needs to be fetched",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "properties": {
+                                "success": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Page not found"
+                    }
+                }
             }
         },
         "/v1/organizations.json": {


### PR DESCRIPTION
## Description
Missing the board delete API call in the API explorer issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
