### PR TITLE
Fixes #3872: In MyRestyaboards iOS app, the load more button in the admin panel activity page should be aligned in centre issue fixed

### DIFF
--- a/client/js/templates/activity_index.jst.ejs
+++ b/client/js/templates/activity_index.jst.ejs
@@ -2,4 +2,6 @@
 <ul class="clearfix list-unstyled" id="js-admin-activity-list">
 
 </ul>
-<div class="btn btn-primary hide" id="js-admin-activites-load-more"><%- i18next.t("Load more activities") %></div>
+<div class="col-xs-12 col-sm-4 col-md-2 text-center">
+    <div class="btn btn-primary hide" id="js-admin-activites-load-more"><%- i18next.t("Load more activities") %></div>
+</div>


### PR DESCRIPTION
## Description
In MyRestyaboards iOS app, the load more button in the admin panel activity page should be aligned in centre issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
