### PR TITLE
Fixes #3683: RangeErrorp(default.cache) error Maximum call stack size exceeded console error thrown issue fixed

### DIFF
--- a/client/js/libs/bootstrap-modal.js
+++ b/client/js/libs/bootstrap-modal.js
@@ -119,11 +119,7 @@
       .off('focusin.bs.modal') // guard against infinite focus loop
       .on('focusin.bs.modal', $.proxy(function (e) {
         if (this.$element[0] !== e.target && !this.$element.has(e.target).length) {
-          try {
-            this.$element.focus()
-          } catch (err) {
-          }
-          
+          this.$element.focus()
         }
       }, this))
   }

--- a/client/js/libs/bootstrap-modal.js
+++ b/client/js/libs/bootstrap-modal.js
@@ -119,7 +119,11 @@
       .off('focusin.bs.modal') // guard against infinite focus loop
       .on('focusin.bs.modal', $.proxy(function (e) {
         if (this.$element[0] !== e.target && !this.$element.has(e.target).length) {
-          this.$element.focus()
+          try {
+            this.$element.focus()
+          } catch (err) {
+          }
+          
         }
       }, this))
   }

--- a/client/js/libs/jquery.fancybox.js
+++ b/client/js/libs/jquery.fancybox.js
@@ -549,10 +549,9 @@
 
                 if ( instance && !$( e.target ).hasClass( 'fancybox-container' ) && !$.contains( instance.$refs.container[0], e.target ) ) {
                     e.stopPropagation();
-                    try {
-                        instance.focus();
-                    } catch (err) {
-                    }
+
+                    instance.focus();
+
                     // Sometimes page gets scrolled, set it back
                     $W.scrollTop( self.scrollTop ).scrollLeft( self.scrollLeft );
                 }
@@ -1978,10 +1977,9 @@
                 $el = this.$refs.container;
 
             }
-            try {
-                $el.focus();
-            } catch (err) {
-            }
+            
+            // Commenting the below code for avoiding the focus on the element while closing
+            //$el.focus();
 
             // Scroll position of wrapper element sometimes changes after focusing (IE)
             this.$refs.slider_wrap.scrollLeft(0);

--- a/client/js/libs/jquery.fancybox.js
+++ b/client/js/libs/jquery.fancybox.js
@@ -549,9 +549,10 @@
 
                 if ( instance && !$( e.target ).hasClass( 'fancybox-container' ) && !$.contains( instance.$refs.container[0], e.target ) ) {
                     e.stopPropagation();
-
-                    instance.focus();
-
+                    try {
+                        instance.focus();
+                    } catch (err) {
+                    }
                     // Sometimes page gets scrolled, set it back
                     $W.scrollTop( self.scrollTop ).scrollLeft( self.scrollLeft );
                 }
@@ -1977,8 +1978,10 @@
                 $el = this.$refs.container;
 
             }
-
-            $el.focus();
+            try {
+                $el.focus();
+            } catch (err) {
+            }
 
             // Scroll position of wrapper element sometimes changes after focusing (IE)
             this.$refs.slider_wrap.scrollLeft(0);


### PR DESCRIPTION
## Description
RangeErrorp(default.cache) error Maximum call stack size exceeded console error thrown issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
