### PR TITLE
Fixes #3711: In add or edit label, we give the labels in first row and then cursor displayed in the second row, and then click "save" button, labels are did not added issue fixed

### DIFF
--- a/client/js/views/modal_card_view.js
+++ b/client/js/views/modal_card_view.js
@@ -769,7 +769,8 @@ App.ModalCardView = Backbone.View.extend({
             }
         });
         labels = labels.substr(0, labels.length - 1);
-        $('.js-show-card-label-form-response').html(new App.CardLabelFormView({
+        $('.js-show-card-label-form-response').html('');
+        $('.js-show-card-label-form-response').append(new App.CardLabelFormView({
             model: labels,
             card: this.model
         }).el);


### PR DESCRIPTION
## Description
In add or edit label, we give the labels in first row and then cursor displayed in the second row, and then click "save" button, labels are did not added issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
