### PR TITLE
Fixes #4095: Image Upload: "File extension not supported. It supports only jpg, png, bmp and gif." issue fixed

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -4144,6 +4144,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
             );
             $filename = $_FILES['attachment']['name'];
             $file_ext = pathinfo($filename, PATHINFO_EXTENSION);
+            $file_ext = strtolower($file_ext);
             if (in_array($file_ext, $allowed_ext)) {
                 $mediadir = MEDIA_PATH . DS . 'Board' . DS . $r_resource_vars['boards'];
                 $save_path = 'Board' . DS . $r_resource_vars['boards'];

--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -2904,6 +2904,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
             );
             $filename = $_FILES['attachment']['name'];
             $file_ext = pathinfo($filename, PATHINFO_EXTENSION);
+            $file_ext = strtolower($file_ext);
             if (in_array($file_ext, $allowed_ext)) {
                 $mediadir = MEDIA_PATH . DS . 'User' . DS . $r_resource_vars['users'];
                 $save_path = 'User' . DS . $r_resource_vars['users'];
@@ -6012,6 +6013,7 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
             );
             $filename = $_FILES['attachment']['name'];
             $file_ext = pathinfo($filename, PATHINFO_EXTENSION);
+            $file_ext = strtolower($file_ext);
             if (in_array($file_ext, $allowed_ext)) {
                 $mediadir = MEDIA_PATH . DS . 'Organization' . DS . $r_resource_vars['organizations'];
                 $save_path = 'Organization' . DS . $r_resource_vars['organizations'];


### PR DESCRIPTION
## Description
Image Upload: "File extension not supported. It supports only jpg, png, bmp and gif." issue fixed

## Related Issue
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
