### PR TITLE
Update docker media path

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - 1234:80
     volumes:
-      - /var/opt/restya/media:/usr/share/nginx/html/media
+      - /var/opt/restya/media:/var/lib/nginx/html/media
     environment:
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432


### PR DESCRIPTION
It looks like docker path has changed. Restyaboard docker was not working for me, changing the path to the location in docker worked fine.

## Description
Just changed the path for the docker media volume

## Related Issue
I believe this is related to #4194.

## Motivation and Context
I just stumbled across this difference between path in docker-compose.yml and where the board data is actually saved inside the container.

## How Has This Been Tested?
Updating the docker-compose.yml made my docker installation work. It was tested on a development and production server. 

## Types of changes
Just a single line.

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation if there are docker versions where there is a different path used.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. (At least for current stable release)
