### PR TITLE
Fixes #4203: While minimizing the modal card and maximize continuously, the modal card header-only shown in the maximized view issue fixed

### DIFF
--- a/client/js/libs/jquery.dockmodal.js
+++ b/client/js/libs/jquery.dockmodal.js
@@ -420,7 +420,9 @@
                 } else {
                     $dockModal.find(".action-popout").attr("title", "Pop-in");
                 }
-
+                if(typeof minimize_set_interval !== undefined){
+                    clearTimeout(minimize_set_interval);
+                }
                 methods.refreshLayout();
 
                 setTimeout(function () {

--- a/client/js/libs/jquery.dockmodal.js
+++ b/client/js/libs/jquery.dockmodal.js
@@ -420,7 +420,7 @@
                 } else {
                     $dockModal.find(".action-popout").attr("title", "Pop-in");
                 }
-                if(typeof minimize_set_interval !== undefined){
+                if (typeof minimize_set_interval !== undefined) {
                     clearTimeout(minimize_set_interval);
                 }
                 methods.refreshLayout();


### PR DESCRIPTION
## Description
While minimizing the modal card and maximize continuously, the modal card header-only shown in the maximized view issue fixed

## Related Issue
[While minimizing the modal card and maximize continuously, the modal card header-only shown in the maximized view](https://github.com/RestyaPlatform/board/issues/4203)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
