### PR TITLE
Fixes #4227: While trying to login as normal user with LDAP app enabled, PHP warning errors thrown issue fixed

### DIFF
--- a/server/php/R/r.php
+++ b/server/php/R/r.php
@@ -2753,13 +2753,13 @@ function r_post($r_resource_cmd, $r_resource_vars, $r_resource_filters, $r_post)
             $where = 'LOWER(username)=LOWER($1)';
         }
         $log_user = executeQuery('SELECT id, role_id, password, is_ldap::boolean::int FROM users WHERE ' . $where, $val_arr);
-        if (is_plugin_enabled('r_ldap_login')) {
+        if (is_plugin_enabled('r_ldap_login') && (empty($log_user) || $log_user['is_ldap'] == 1)) {
             require_once PLUGIN_PATH . DS . 'LdapLogin' . DS . 'functions.php';
             $ldap_response = ldapUpdateUser($log_user, $r_post);
             $ldap_error = $ldap_response['ldap_error'];
             $user = $ldap_response['user'];
         }
-        if (is_plugin_enabled('r_multiple_ldap_login')) {
+        if (is_plugin_enabled('r_multiple_ldap_login') && (empty($log_user) || $log_user['is_ldap'] == 1)) {
             require_once PLUGIN_PATH . DS . 'MultipleLdapLogin' . DS . 'functions.php';
             $ldap_response = ldapUpdateUser($log_user, $r_post);
             $ldap_error = $ldap_response['ldap_error'];


### PR DESCRIPTION
## Description
While trying to login as normal user with LDAP app enabled, PHP warning errors thrown issue fixed

## Related Issue
[While trying to login as normal user with LDAP app enabled, PHP warning errors thrown](https://github.com/RestyaPlatform/board/issues/4227)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
