### PR TITLE
Fixes #4248: SSL certificates are not obtained while trying to get the certifictaes for the domain using the installation script issue fixed

### DIFF
--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -1776,9 +1776,9 @@
 			else
 				user nginx;
 				usermod -a -G restyaboard nginx
-				sed -i "s/\[www\]/restyaboard/g" /etc/php/7.4/fpm/pool.d/www.conf
-				sed -i "s/user\s*=\s*www-data/user = restyaboard/g" /etc/php/7.4/fpm/pool.d/www.conf
-				sed -i "0,/group\s*=\s*www-data/s//group = restyaboard/g" /etc/php/7.4/fpm/pool.d/www.conf
+				sed -i "s/\[www\]/[restyaboard] group=restyaboard/g" /etc/php-fpm.d/www.conf
+				sed -i "s/user\s*=\s*apache/user = restyaboard/g" /etc/php-fpm.d/www.conf
+				sed -i "0,/group\s*=\s*apache/s//group = restyaboard/g" /etc/php-fpm.d/www.conf
 			fi
 			chown -R restyaboard:restyaboard $dir
 			chmod -R u=rwX,g=rX,o= $dir


### PR DESCRIPTION
## Description
SSL certificates are not obtained while trying to get the certifictaes for the domain using the installation script issue fixed

## Related Issue
[SSL certificates are not obtained while trying to get the certifictaes for the domain using the installation script](https://github.com/RestyaPlatform/board/issues/4248)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
