### PR TITLE
Fixes #4248: SSL certificates are not obtained while trying to get the certifictaes for the domain using the installation script issue fixed

### DIFF
--- a/restyaboard.sh
+++ b/restyaboard.sh
@@ -1834,6 +1834,10 @@
 				chown -R restyaboard:restyaboard "$dir/client/apps"
 				chmod -R u=rwX,g=rX,o= "$dir/client/apps"
 				chmod -R u=rwX,g=rX,o= $dir/client/apps/**/*.json
+				if ([ "$OS_REQUIREMENT" = "CentOS" ])
+				then
+					chcon -R -t httpd_sys_rw_content_t $dir/client/apps/**/*.json
+				fi
 			esac
 			if ([ "$OS_REQUIREMENT" = "Ubuntu" ] || [ "$OS_REQUIREMENT" = "Debian" ] || [ "$OS_REQUIREMENT" = "LinuxMint" ] || [ "$OS_REQUIREMENT" = "Raspbian" ])
 			then


### PR DESCRIPTION
## Description
SSL certificates are not obtained while trying to get the certifictaes for the domain using the installation script issue fixed

## Related Issue
[SSL certificates are not obtained while trying to get the certifictaes for the domain using the installation script](https://github.com/RestyaPlatform/board/issues/4248)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
